### PR TITLE
ci: ensure that the PR title follows "Conventional Commits"

### DIFF
--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,0 +1,14 @@
+name: Check Pull Request Metadata
+on:
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2


### PR DESCRIPTION
Add a dedicated workflow to enforce the rule. It runs on `pull_request_target` to handle PR created by Dependabot and from fork repositories.