### PR TITLE
chore: fix workflows used to release and publish npm package

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,6 +16,7 @@ jobs:
         uses: ./.github/actions/build-setup
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish -w packages/addons
+      # scoped package requires "access=public"
+      - run: npm publish -w packages/addons --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,6 @@ jobs:
         run: git checkout main && git pull --tags
       - name: Bump Version
         run: |
-          npm version ${{ github.event.inputs.type }} --no-commit-hooks --message "chore(release): %s"
+          npm version ${{ github.event.inputs.type }} --no-commit-hooks --message "chore(release): %s" -w packages/addons
       - name: Push Version
         run: git push && git push --tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "bv-addons-root",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,8 +8,7 @@
       "name": "bv-addons-root",
       "workspaces": [
         "./packages/*"
-      ],
-      "version": "0.1.0"
+      ]
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1855,6 +1855,5 @@
         "node": ">=4.2.0"
       }
     }
-  },
-  "version": "0.1.0"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "bv-addons-root",
-  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1825,7 +1825,7 @@
     },
     "packages/addons": {
       "name": "@process-analytics/bv-experimental-add-ons",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "npm-run-all": "~4.1.5",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,5 @@
   "private": true,
   "workspaces": [
     "./packages/*"
-  ],
-  "version": "0.1.0"
+  ]
 }

--- a/packages/addons/.npmrc
+++ b/packages/addons/.npmrc
@@ -1,4 +1,0 @@
-# scoped package
-access=public
-# publish is only done with GitHub Actions which supports "provenance"
-provenance=true

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@process-analytics/bv-experimental-add-ons",
   "version": "0.1.0",
+  "private": false,
   "description": "Experimental add-ons for bpmn-visualization",
   "keywords": [
     "analytics",

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-analytics/bv-experimental-add-ons",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Experimental add-ons for bpmn-visualization",
   "keywords": [
     "analytics",


### PR DESCRIPTION
Configuration updates:
  - Add the missing workspace directive in the "release" workflow. The version in the root package.json file was previously updated instead of the versions in the addons workspace.
  - "npm publish" workflow: pass cli option instead of using .npmrc file (not sure it was used, command is now more explicit).
  - Explicitly mark the addons workspace as public in package.json. This ensures that the value is not inherited from the root package.json.

Fix the versions in package.json files that have been incorrectly updated in v0.1.0:
  - Revert version added to the root package.json. This is not the package that should have been published.
  - Restore the right version in the "addons" workspace.