### PR TITLE
chore(release): correctly tag when bumping the version of the package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,6 @@ jobs:
         run: git checkout main && git pull --tags
       - name: Bump Version
         run: |
-          npm version ${{ github.event.inputs.type }} --no-commit-hooks --message "chore(release): %s" -w packages/addons
+          ./bin/version.bash addons ${{ github.event.inputs.type }}
       - name: Push Version
         run: git push && git push --tags

--- a/bin/version.bash
+++ b/bin/version.bash
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+# inspired by https://github.com/textbook/fauxauth/blob/v8.1.5/bin/version.sh
+
+if [ $# -ne 2 ]; then
+  echo "usage: ./bin/version.bash <package> <version>"
+  echo "This will update the version for the give package"
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo 'Git working directory not clean.'
+  exit 1
+fi
+
+packageName=$1
+npmVersion=$2
+
+echo "Bumping package ${packageName} to ${npmVersion}"
+npm version ${npmVersion} --no-git-tag-version -w packages/${packageName}
+
+VERSION=`node -p "require('./packages/${packageName}/package.json').version"`
+echo "New package version: ${VERSION}"
+
+echo "Committing and tagging..."
+git commit -a --message "chore(release): ${VERSION}"
+git tag "v${VERSION}"
+echo "Commit and tag done"


### PR DESCRIPTION
The "npm version" command does not commit changes when used to bump the version of a workspace. So, introduce a script that create the commit and the tag.