### PR TITLE
chore(dev-deps): bump dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "./packages/*"
       ],
       "devDependencies": {
-        "concurrently": "~8.2.0"
+        "concurrently": "~8.2.0",
+        "typescript": "~5.1.6"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2075,9 +2076,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.26.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.3.tgz",
-      "integrity": "sha512-7Tin0C8l86TkpcMtXvQu6saWH93nhG3dGQ1/+l5V2TDMceTxO7kDiK6GzbfLWNNxqJXm591PcEZUozZm51ogwQ==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
+      "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2601,14 +2602,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.6.tgz",
-      "integrity": "sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
-        "postcss": "^8.4.26",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2906,8 +2907,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "npm-run-all": "~4.1.5",
-        "rimraf": "~5.0.1",
-        "typescript": "~5.1.6"
+        "rimraf": "~5.0.1"
       },
       "peerDependencies": {
         "bpmn-visualization": ">=0.37.0"
@@ -2938,8 +2938,7 @@
         "bpmn-visualization": "~0.37.0"
       },
       "devDependencies": {
-        "typescript": "~5.1.6",
-        "vite": "~4.4.6"
+        "vite": "~4.4.9"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "concurrently -n lib,demo \"npm run dev -w packages/addons\" \"npm run dev -w packages/demo\""
   },
   "devDependencies": {
-    "concurrently": "~8.2.0"
+    "concurrently": "~8.2.0",
+    "typescript": "~5.1.6"
   }
 }

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "npm-run-all": "~4.1.5",
-    "rimraf": "~5.0.1",
-    "typescript": "~5.1.6"
+    "rimraf": "~5.0.1"
   }
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -11,7 +11,6 @@
     "bpmn-visualization": "~0.37.0"
   },
   "devDependencies": {
-    "typescript": "~5.1.6",
-    "vite": "~4.4.6"
+    "vite": "~4.4.9"
   }
 }


### PR DESCRIPTION
Bump vite from 4.4.6 to 4.4.9.
Declare typescript at project root to avoid duplication.