### PR TITLE
feat: introduce plugins infrastructure and add `OverlaysPlugin`

### DIFF
--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -3,7 +3,46 @@
 Experimental add-ons for [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js).
 
 
+## 📌 Usage
+<!-- ### 📌 Usage in applications and projects -->
+
+Install `bv-experimental-add-ons` and [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js/):
+```shell script
+npm i @process-analytics/bv-experimental-add-ons bpmn-visualization
+```
+
+
+## 📜 TypeScript Support
+
+The `@process-analytics/bv-experimental-add-ons` npm package includes type definitions, so the integration works out of the box in TypeScript projects and applications.
+`bv-experimental-add-ons` requires **TypeScript 4.5** or greater.
+
+
 ## 🎨 Features
+
+### Plugins
+
+The plugins infrastructure provides a way to register extension points.
+
+Example of use:
+
+```ts
+// use BpmnVisualization from addons not from bpmn-visualization
+import {BpmnVisualization} from "@process-analytics/bv-experimental-add-ons";
+
+const bpmnVisualization = new BpmnVisualization({
+    container: 'bpmn-container',
+    plugins: [MyPlugin]
+});
+// Retrieve the plugin by id. The id is defined in the plugin implementation
+const myPlugin = bpmnVisualization.getPlugin('my-plugin') as MyPlugin;
+myPlugin.aMethod();
+```
+
+#### Available plugins
+
+- `OverlaysPlugin`: let show/hide overlays created with `BpmnElementsRegistry.addOverlays`.
+
 
 ### `BpmnElementsIdentifier`
 
@@ -35,21 +74,6 @@ Use it to bypass the limitations of the tools and algorithms provided in the bac
 ### `ShapeUtil`
 
 Add new methods to the `ShapeUtil` class provided by `bpmn-visualization`. 
-
-
-## 📌 Usage
-<!-- ### 📌 Usage in applications and projects -->
-
-Install `bv-experimental-add-ons` and [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js/):
-```shell script
-npm i @process-analytics/bv-experimental-add-ons bpmn-visualization
-```
-
-
-## 📜 TypeScript Support
-
-The `@process-analytics/bv-experimental-add-ons` npm package includes type definitions, so the integration works out of the box in TypeScript projects.
-`bv-experimental-add-ons` requires **TypeScript 4.5** or greater.
 
 
 ## 📃 License

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsc --watch",
+    "dev": "tsc --watch --sourceMap",
     "build": "tsc",
     "clean": "rimraf dist",
     "prepack": "run-s clean build"

--- a/packages/addons/src/index.ts
+++ b/packages/addons/src/index.ts
@@ -16,3 +16,4 @@ limitations under the License.
 
 export * from './bpmn-elements';
 export * from './paths';
+export * from './plugins-support';

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -24,6 +24,19 @@ export interface Plugin {
     getPluginId(): string;
 }
 
+/**
+ * Let pass plugins configuration to {@link BpmnVisualization}.
+ *
+ * Use this type if you already have a dedicated custom `GlobalOptions` type extending the bpmn-visualization `GlobalOptions` type.
+ * In this case, proceed as in the following example to add the plugins configuration to the custom `GlobalOptions`.
+ *
+ * ```ts
+ * // Assuming you have a `CustomGlobalOptions`
+ * type GlobalOptionsWithPluginsSupport = CustomGlobalOptions & PluginOptionExtension;
+ * ```
+ *
+ * If you don't extend `GlobalOptions`, use {@link GlobalOptions} directly.
+ */
 export type PluginOptionExtension = {
     plugins?: PluginConstructor[];
 };

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -32,19 +32,19 @@ export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
 
 export class BpmnVisualization extends BaseBpmnVisualization {
 
-    private readonly plugins: Record<string, Plugin> = {};
+    private readonly plugins: Map<string, Plugin> = new Map();
 
     constructor(options: GlobalOptions) {
         super(options);
 
         options.plugins?.forEach((constructor: PluginConstructor) => {
             const plugin = new constructor(this, options);
-            this.plugins[plugin.getPluginId()] = plugin;
+            this.plugins.set(plugin.getPluginId(), plugin);
         });
         console.info('[bv-addons] Registered plugins:', this.plugins);
     }
 
-    getPlugin = (id: string) => this.plugins[id] as unknown;
+    getPlugin = (id: string) => this.plugins.get(id) as unknown;
 }
 
 export class OverlaysPlugin implements Plugin {

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -44,7 +44,10 @@ export class BpmnVisualization extends BaseBpmnVisualization {
         console.info('[bv-addons] Registered plugins:', this.plugins);
     }
 
-    getPlugin = (id: string) => this.plugins.get(id) as unknown;
+    getPlugin(id: string): unknown {
+        // no need to return a Plugin type, methods of this type are useless for consumers
+        return this.plugins.get(id) as unknown;
+    }
 }
 
 export class OverlaysPlugin implements Plugin {

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {BpmnVisualization as BaseBpmnVisualization, type GlobalOptions as BaseGlobalOptions} from "bpmn-visualization";
+
+export interface PluginConstructor {
+    new (bpmnVisualization: BpmnVisualization, options: GlobalOptions): Plugin;
+}
+
+export interface Plugin {
+    getPluginId(): string;
+}
+
+export type PluginOptionExtension = {
+    plugins?: PluginConstructor[];
+};
+
+export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
+
+export class BpmnVisualization extends BaseBpmnVisualization {
+
+    private readonly plugins: Record<string, Plugin> = {};
+
+    constructor(options: GlobalOptions) {
+        super(options);
+
+        options.plugins?.forEach((constructor: PluginConstructor) => {
+            const plugin = new constructor(this, options);
+            this.plugins[plugin.getPluginId()] = plugin;
+        });
+        console.info('[bv-addons] Registered plugins:', this.plugins);
+    }
+
+    getPlugin = (id: string) => this.plugins[id] as unknown;
+}
+
+export class OverlaysPlugin implements Plugin {
+    private readonly overlayPane: HTMLElement;
+    private previousStyleDisplay?: string;
+    private isVisible = true;
+
+    constructor(bpmnVisualization: BpmnVisualization) {
+        const view = bpmnVisualization.graph.getView();
+        this.overlayPane = view.getOverlayPane() as HTMLElement;
+    }
+
+    setVisible(visible = true): void {
+        if (visible && !this.isVisible) {
+            this.overlayPane.style.display = this.previousStyleDisplay ?? '';
+            this.isVisible = true;
+        } else if (!visible && this.isVisible) {
+            this.previousStyleDisplay = this.overlayPane.style.display;
+            this.overlayPane.style.display = 'none';
+            this.isVisible = false;
+        }
+    }
+
+    getPluginId(): string {
+        return 'overlays';
+    }
+}

--- a/packages/demo/index.html
+++ b/packages/demo/index.html
@@ -27,6 +27,7 @@
 <section class="demos">
     <h1>Available demos</h1>
     <ul>
+        <li><a href="pages/overlays.html">OverlaysPlugin</a>: Show how to use the <code>OverlaysPlugin</code> and demonstrate its features.</li>
         <li><a href="./pages/path-resolver.html">PathResolver</a>: Infer path after selecting some flow nodes.</li>
     </ul>
     As a reminder, <code>bpmn-visualization</code> examples and demos: <a href="https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/index.html" target="_blank"><i>⏩ live environment</i></a>

--- a/packages/demo/pages/overlays.html
+++ b/packages/demo/pages/overlays.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/assets/logo.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>bv-addons OverlaysPlugin demo</title>
+    <script type="module" src="/src/overlays.ts"></script>
+  </head>
+  <body>
+    <header>
+      <a href="../"><img src="/assets/logo.svg" id="logo" alt="The Process Analytics project logo" class="logo" title="Back to home"></a>
+      <h1>OverlaysPlugin demo</h1>
+    </header>
+    <section class="presentation">
+      <div class="description">Show how to use the <code>OverlaysPlugin</code> and demonstrate its features.</div>
+      <div class="controls">
+        <button id="btn-overlays-visibility">Hide overlays</button>
+      </div>
+    </section>
+    <div id="bpmn-container"></div>
+  </body>
+</html>

--- a/packages/demo/src/overlays.ts
+++ b/packages/demo/src/overlays.ts
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import './path-resolver.css';
+import {FitType} from 'bpmn-visualization';
+import {BpmnVisualization, OverlaysPlugin} from "@process-analytics/bv-experimental-add-ons";
+// This is simple example of the BPMN diagram, loaded as string. The '?.raw' extension support is provided by Vite.
+// For other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
+import diagram from './diagram.bpmn?raw';
+
+// Instantiate BpmnVisualization, and pass the OverlaysPlugin
+const bpmnVisualization = new BpmnVisualization({
+  container: 'bpmn-container',
+  navigation: {enabled: false},
+  plugins: [OverlaysPlugin]
+});
+// Load the BPMN diagram defined above
+bpmnVisualization.load(diagram, {fit: {type: FitType.Center, margin: 20}});
+
+// Add overlays
+const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+const overlayStyle = {stroke: {color: 'chartreuse'}, fill: {color: 'chartreuse'}, font: {color: 'white', size: 18}};
+// SRM subprocess
+bpmnElementsRegistry.addOverlays('Activity_0ec8azh', {label: '123', position: 'top-center', style: overlayStyle});
+// Record Service Entry Sheet
+bpmnElementsRegistry.addOverlays('Activity_06cvihl', {label: '100', position: 'top-left', style: overlayStyle});
+// Record Invoice Receipt
+bpmnElementsRegistry.addOverlays('Activity_1u4jwkv', {label: '123', position: 'bottom-center', style: overlayStyle});
+// Remove Payment Block
+bpmnElementsRegistry.addOverlays('Activity_083jf01', {label: '147', position: 'top-right', style: overlayStyle});
+
+// Configure button to hide/show overlays
+const overlaysPlugin = bpmnVisualization.getPlugin('overlays') as OverlaysPlugin;
+let isOverlaysVisible = true;
+const overlaysVisibilityButton = document.querySelector('#btn-overlays-visibility') as HTMLButtonElement;
+const handleOverlaysVisibility = () => {
+  isOverlaysVisible = !isOverlaysVisible;
+  overlaysPlugin.setVisible(isOverlaysVisible);
+  overlaysVisibilityButton.innerText = isOverlaysVisible ? 'Hide overlays' : 'Show overlays';
+};
+
+overlaysVisibilityButton.addEventListener('click', _ev => {
+  handleOverlaysVisibility();
+});

--- a/packages/demo/src/path-resolver.css
+++ b/packages/demo/src/path-resolver.css
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*NOTE: also used in "overlays.html"*/
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   font-weight: 400;

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -14,18 +14,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { resolve } from 'node:path';
+import { parse, resolve } from 'node:path';
 import { defineConfig } from 'vite';
+
+
+import { readdirSync, readFileSync as fsReadFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// =====================================================================================================================
+// Taken from bpmn-visualization test/shared/file-helper.ts
+/** Returns the files in the given directory. The function doesn't do any recursion in subdirectories. */
+function findFiles(relPathToSourceDirectory: string): string[] {
+  return readdirSync(join(__dirname, relPathToSourceDirectory));
+}
+// =====================================================================================================================
+
+function generateInput() {
+  const pages = findFiles('pages');
+  const input: {[p: string]: string} = {
+    index: resolve(__dirname, 'index.html'),
+  };
+  for (const page of pages) {
+    input[parse(page).name] = resolve(__dirname, `pages/${page}`);
+  }
+  return input;
+}
 
 export default defineConfig(() => {
   return {
     build: {
       rollupOptions: {
-        input: {
-          // TODO compute the list of HTML pages automatically
-          index: resolve(__dirname, 'index.html'),
-          'path-resolver': resolve(__dirname, 'pages/path-resolver.html'),
-        },
+        input: generateInput(),
         output: {
           manualChunks: {
             // put mxgraph code in a dedicated file.


### PR DESCRIPTION
This infrastructure is a first try to propose extension points with plugins. It is subject to change in the future.
The `OverlaysPlugin` demonstrates how to create and use a plugin. It provides a method to show or hide overlays. They stay in the DOM contrarily to the `BpmnElementsRegistry.removeOverlays` method that actually removes overlays from the model.
Hiding overlays supports BPMN navigation which means that the overlays stay hidden while panning and zooming.

Demo
  - create a dedicated demo for the `OverlaysPlugin`
  - packaging: all pages of the demo are automatically packaged within the distribution. Previously, they had to be declared manually.

Build of the 'addons' lib: generate sourceMap to easily debug the demo.

### Notes

closes #8 

The idea of having a method to hide/show overlays comes from https://github.com/process-analytics/bpmn-visualization-js/issues/1217: mxGraph stores overlays in a dedicated HTML element, so it is easy to hide it.

The BPMN navigation doesn't remove the style applied externally from mxGraph (to hide the overlays) as shown in the video below 👇🏿. It is currently not activated in the demo because when doing a panning to the bottom of the page, the container height increases. This probably occurs because the height is not detected as a 'fixed' value. This will enable later.

https://github.com/process-analytics/bv-experimental-add-ons/assets/27200110/f2e87314-edb2-46c5-bfe7-9d767952b395


