### PR TITLE
refactor(demo): remove hack for `resetStyle`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -581,12 +581,12 @@
       "dev": true
     },
     "node_modules/bpmn-visualization": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-0.37.0.tgz",
-      "integrity": "sha512-KZhFmiApyRp3gNXd+nZVz5Ff1R8CoYu86C1H0xLxspPOG4aCOATzjjW+S02XQyK/BfDyUIgeXCDvufQDf63l+A==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-0.38.1.tgz",
+      "integrity": "sha512-yuUfzvfIomy1mGnX9VEj8JLdcRsOypLjFkVNRm8ve84V5EORMKMMLET2OD/MvrKIfrPu46/sFd3BTdX716TrMQ==",
       "dependencies": {
         "@typed-mxgraph/typed-mxgraph": "~1.0.8",
-        "fast-xml-parser": "4.2.5",
+        "fast-xml-parser": "4.2.7",
         "lodash-es": "~4.17.21",
         "mxgraph": "4.2.2",
         "strnum": "1.0.5"
@@ -1100,9 +1100,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.7.tgz",
+      "integrity": "sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==",
       "funding": [
         {
           "type": "paypal",
@@ -2935,7 +2935,7 @@
     "packages/demo": {
       "name": "bv-addons-demo",
       "dependencies": {
-        "bpmn-visualization": "~0.37.0"
+        "bpmn-visualization": "~0.38.1"
       },
       "devDependencies": {
         "vite": "~4.4.9"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --base ./"
   },
   "dependencies": {
-    "bpmn-visualization": "~0.37.0"
+    "bpmn-visualization": "~0.38.1"
   },
   "devDependencies": {
     "vite": "~4.4.9"

--- a/packages/demo/src/path-resolver.ts
+++ b/packages/demo/src/path-resolver.ts
@@ -43,8 +43,7 @@ const computedFlows: string[] = [];
 
 function computePath() {
   // reset style of previously computed flows
-  // TODO bug bpmn-visualization, resetStyle with empty array acts like if it undefined (reset all)
-  computedFlows.length > 0 && bpmnElementsRegistry.resetStyle(computedFlows);
+  bpmnElementsRegistry.resetStyle(computedFlows);
   computedFlows.length = 0;
 
   const visitedEdges = pathResolver.getVisitedEdges([...selectedBpmnElements]);


### PR DESCRIPTION
Previously, the code contained a trick to avoid passing an empty array to the `resetStyle` method. This method was buggy and would otherwise have reset the style of all elements.

The problem is now fixed
  - bump bpmn-visualization from 0.37.0 to 0.38.1
  - remove the hack

closes #67