### PR TITLE
refactor: fix Code Smells detected by SonarCloud

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       ],
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "~6.4.0",
+        "@typescript-eslint/parser": "~6.4.0",
         "concurrently": "~8.2.0",
         "eslint": "~8.47.0",
         "eslint-config-prettier": "~9.0.0",
@@ -789,7 +790,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
       "integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.4.1",
         "@typescript-eslint/types": "6.4.1",

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -16,9 +16,7 @@ limitations under the License.
 
 import { BpmnVisualization as BaseBpmnVisualization, type GlobalOptions as BaseGlobalOptions } from 'bpmn-visualization';
 
-export interface PluginConstructor {
-  new (bpmnVisualization: BpmnVisualization, options: GlobalOptions): Plugin;
-}
+export type PluginConstructor = new (bpmnVisualization: BpmnVisualization, options: GlobalOptions) => Plugin;
 
 export interface Plugin {
   getPluginId(): string;
@@ -53,8 +51,6 @@ export class BpmnVisualization extends BaseBpmnVisualization {
       const plugin = new constructor(this, options);
       this.plugins.set(plugin.getPluginId(), plugin);
     });
-    // eslint-disable-next-line no-console
-    console.info('[bv-addons] Registered plugins:', this.plugins);
   }
 
   getPlugin(id: string): unknown {

--- a/packages/demo/src/path-resolver.ts
+++ b/packages/demo/src/path-resolver.ts
@@ -61,8 +61,7 @@ function clearPath(): void {
 const getAllFlowNodes = (): BpmnElement[] => bpmnElementsRegistry.getElementsByKinds(ShapeUtil.flowNodeKinds().filter(kind => !ShapeUtil.isBpmnArtifact(kind)));
 
 const setupBpmnElementEventHandlers = (): void => {
-  // TODO use "for of instead"
-  getAllFlowNodes().forEach(item => {
+  for (const item of getAllFlowNodes()) {
     const currentId = item.bpmnSemantic.id;
     const htmlElement = item.htmlElement;
     htmlElement.onclick = () => {
@@ -77,7 +76,7 @@ const setupBpmnElementEventHandlers = (): void => {
     htmlElement.onmouseenter = _ev => {
       htmlElement.style.cursor = 'pointer';
     };
-  });
+  }
 };
 
 const setupControlEventHandlers = (): void => {

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -14,11 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { parse, resolve } from 'node:path';
-import { defineConfig } from 'vite';
-
+import { join, parse, resolve } from 'node:path';
 import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { defineConfig } from 'vite';
 
 // =====================================================================================================================
 // Taken from bpmn-visualization test/shared/file-helper.ts


### PR DESCRIPTION
Fix code smells:
  - addons
    - `PluginConstructor`: switch from an interface with a single method to function for simplicity
  - demo
    - `vite.config.ts`: rework imports
    - `setupBpmnElementEventHandlers`: switch from _forEach_ to _for...of_ and remove the related TODO

Additional improvements
  - `BpmnVisualization` plugins support: remove console.info. It is not needed, if we want to let users diagnose the loaded plugins, we will provide a dedicated method or options later.
  - `package-lock.json`: add missing declaration of `@typescript-eslint/parser`

closes #71