### PR TITLE
chore(dev-deps): restore usage of typescript 4.5.2 in check-ts-support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5479,7 +5479,20 @@
     "packages/check-ts-support": {
       "name": "check-lowest-typescript-version",
       "devDependencies": {
-        "typescript": "5.2.2"
+        "typescript": "4.5.2"
+      }
+    },
+    "packages/check-ts-support/node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "packages/demo": {

--- a/packages/check-ts-support/package.json
+++ b/packages/check-ts-support/package.json
@@ -5,6 +5,6 @@
     "test": "tsc --version && tsc"
   },
   "devDependencies": {
-    "typescript": "5.2.2"
+    "typescript": "4.5.2"
   }
 }


### PR DESCRIPTION
This version must be kept to 4.5.
This package ensures that the type definitions are valid for TypeScript 4.5+.