### PR TITLE
chore(dependabot): do not update typescript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
       - skip-changelog
     reviewers:
       - process-analytics/pa-collaborators
+    ignore:
+      # typescript must not be updated in packages/check-ts-support. Its version must remain unchanged to test the minimum version supported by bv-addons
+      # For more details, see:
+      #    https://github.com/process-analytics/bv-experimental-add-ons/pull/90
+      #    https://github.com/process-analytics/bv-experimental-add-ons/pull/92
+      - dependency-name: "typescript"
     groups:
        css:
           patterns:


### PR DESCRIPTION
typescript must not be updated in packages/check-ts-support. Its version must remain unchanged to test the minimum version supported by bv-experimental-add-ons .
Currently, it is not possible to configure dependabot to ignore this specific package, so ignore the update on the whole project.

Relates to #90 and #92.