### PR TITLE
chore: move project to ESM

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Bonitasoft S.A.
+Copyright 2023 Bonitasoft S.A.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/**
+ * @type {import("eslint").Linter.Config}
+ */
 module.exports = {
   root: true,
   plugins: ['notice'],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,7 @@ updates:
             - "tailwindcss"
        lint:
           patterns:
+            - "@types/eslint"
             - "@typescript-eslint/*"
             - "eslint"
             - "eslint-*"

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,25 @@
-module.exports = {
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const config = {
   semi: true,
-  trailingComma: "all",
+  trailingComma: 'all',
   singleQuote: true,
-  arrowParens:"avoid",
-  endOfLine:"auto"
+  arrowParens: 'avoid',
+  endOfLine: 'auto',
 };
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "./packages/*"
       ],
       "devDependencies": {
+        "@types/eslint": "~8.44.2",
         "@typescript-eslint/eslint-plugin": "~6.5.0",
         "@typescript-eslint/parser": "~6.5.0",
         "concurrently": "~8.2.1",
@@ -702,6 +703,22 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.8.tgz",
       "integrity": "sha512-rzTbmD/XofRq0YZMY/BU9cjbCTw9q8rpIvWRhQO0DcgCx3+rpHTsVOk3pfuhcnUigUYNFkljmDkRuVjbl7zZoQ=="
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.44.2",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
+      "integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
   "name": "bv-addons-root",
   "private": true,
+  "type": "module",
   "workspaces": [
     "./packages/*"
   ],
   "scripts": {
-    "lint": "eslint \"**/*.{js,mjs,ts}\" --max-warnings 0 --quiet --fix",
-    "lint-check": "eslint \"**/*.{js,mjs,ts}\" --max-warnings 0",
+    "lint": "eslint \"**/*.{js,cjs,mjs,ts,cts,mts}\" --max-warnings 0 --quiet --fix",
+    "lint-check": "eslint \"**/*.{js,cjs,mjs,ts,cts,mts}\" --max-warnings 0",
     "prepare": "husky install",
     "start": "concurrently -n lib,demo \"npm run dev -w packages/addons\" \"npm run dev -w packages/demo\""
   },
   "devDependencies": {
+    "@types/eslint": "~8.44.2",
     "@typescript-eslint/eslint-plugin": "~6.5.0",
     "@typescript-eslint/parser": "~6.5.0",
     "concurrently": "~8.2.1",
@@ -23,7 +25,7 @@
     "typescript": "~5.2.2"
   },
   "lint-staged": {
-    "*.{js,mjs,ts}": [
+    "*.{js,cjs,mjs,ts,cts,mts}": [
       "eslint --fix"
     ]
   }

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -2,6 +2,8 @@
   "name": "@process-analytics/bv-experimental-add-ons",
   "version": "0.3.0",
   "private": false,
+  "type": "module",
+  "sideEffects": false,
   "description": "Experimental add-ons for bpmn-visualization",
   "keywords": [
     "analytics",
@@ -21,8 +23,16 @@
     "url": "git+https://github.com/process-analytics/bv-experimental-add-ons.git"
   },
   "module": "./dist/index.js",
-  "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/packages/check-ts-support/package.json
+++ b/packages/check-ts-support/package.json
@@ -1,6 +1,7 @@
 {
   "name": "check-lowest-typescript-version",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "tsc --version && tsc"
   },


### PR DESCRIPTION
Instruct Node.js to consider .js file as ESM module.
The `package.json` file now declares "exports". This can be useful when testing code using bv-addons in a Node.js environment.
It's also marked as having no side effects ("sideEffects": false) to enable tools like webpack to better manage tree shaking.

Configure tools to manage all specific JS/TS extension.
  - Migrate configuration files to ESM.
  - The eslint configuration file is still using CommonJS because v8.48.0 doesn't support ESM. Add typings to ease configuration change in IDE.


### Notes

Based on work done during #95 and #96
See also https://github.com/process-analytics/bpmn-visualization-js/pull/2840

Resources
- https://nodejs.org/docs/latest-v18.x/api/packages.html#conditional-exports
- https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
- side effects free: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
