### PR TITLE
feat: improve the robustness of `PathResolver`

### DIFF
--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnElementsRegistry, EdgeBpmnSemantic, ShapeBpmnSemantic } from 'bpmn-visualization';
+import type { BpmnElementsRegistry, ShapeBpmnSemantic } from 'bpmn-visualization';
 
 /**
  * Experimental implementation for {@link https://github.com/process-analytics/bpmn-visualization-js/issues/930}
@@ -28,34 +28,16 @@ export class PathResolver {
    * @param shapeIds
    */
   getVisitedEdges(shapeIds: string[]): string[] {
-    const edgeIds = new Set<string>();
-    for (const shapeId of shapeIds) {
-      const shapeElt = this.bpmnElementsRegistry.getModelElementsByIds(shapeId)[0];
-      // filter non-existing elements and edges
-      if (!shapeElt?.isShape) {
-        continue;
-      }
+    const incomingIds = [] as string[];
+    const outgoingIds = [] as string[];
 
-      const bpmnSemantic = shapeElt as ShapeBpmnSemantic;
-      const incomingEdges = bpmnSemantic.incomingIds;
-      const outgoingEdges = bpmnSemantic.outgoingIds;
-      for (const edgeId of incomingEdges) {
-        const edgeElement = this.bpmnElementsRegistry.getModelElementsByIds(edgeId)[0];
-        const sourceRef = (edgeElement as EdgeBpmnSemantic).sourceRefId;
-        if (shapeIds.includes(sourceRef)) {
-          edgeIds.add(edgeId);
-        }
-      }
-
-      for (const edgeId of outgoingEdges) {
-        const edgeElement = this.bpmnElementsRegistry.getModelElementsByIds(edgeId)[0];
-        const targetRef = (edgeElement as EdgeBpmnSemantic).targetRefId;
-        if (shapeIds.includes(targetRef)) {
-          edgeIds.add(edgeId);
-        }
-      }
+    const shapes = this.bpmnElementsRegistry.getModelElementsByIds(shapeIds).filter(element => element.isShape) as ShapeBpmnSemantic[];
+    for (const shape of shapes) {
+      incomingIds.push(...shape.incomingIds);
+      outgoingIds.push(...shape.outgoingIds);
     }
 
-    return Array.from(edgeIds);
+    // TODO add test to show we manage duplicates
+    return incomingIds.filter(incomingId => outgoingIds.includes(incomingId));
   }
 }

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -22,15 +22,20 @@ import type { BpmnElementsRegistry, EdgeBpmnSemantic, ShapeBpmnSemantic } from '
 export class PathResolver {
   constructor(private readonly bpmnElementsRegistry: BpmnElementsRegistry) {}
 
+  /**
+   * Currently, if the shapeIds parameter contains ids related to edges, these ids are ignored and not returned as part of the visited edges.
+   *
+   * @param shapeIds
+   */
   getVisitedEdges(shapeIds: string[]): string[] {
     const edgeIds = new Set<string>();
     for (const shapeId of shapeIds) {
       const shapeElt = this.bpmnElementsRegistry.getModelElementsByIds(shapeId)[0];
-      if (!shapeElt) {
+      // filter non existing element and edge
+      if (!shapeElt || !shapeElt.isShape) {
         continue;
       }
 
-      // TODO filter edge
       const bpmnSemantic = shapeElt as ShapeBpmnSemantic;
       const incomingEdges = bpmnSemantic.incomingIds;
       const outgoingEdges = bpmnSemantic.outgoingIds;

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -32,7 +32,7 @@ export class PathResolver {
     for (const shapeId of shapeIds) {
       const shapeElt = this.bpmnElementsRegistry.getModelElementsByIds(shapeId)[0];
       // filter non existing element and edge
-      if (!shapeElt || !shapeElt.isShape) {
+      if (!shapeElt?.isShape) {
         continue;
       }
 

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -25,25 +25,26 @@ export class PathResolver {
   getVisitedEdges(shapeIds: string[]): string[] {
     const edgeIds = new Set<string>();
     for (const shapeId of shapeIds) {
-      const shapeElt = this.bpmnElementsRegistry.getElementsByIds(shapeId)[0];
+      const shapeElt = this.bpmnElementsRegistry.getModelElementsByIds(shapeId)[0];
       if (!shapeElt) {
         continue;
       }
 
-      const bpmnSemantic = shapeElt.bpmnSemantic as ShapeBpmnSemantic;
+      // TODO filter edge
+      const bpmnSemantic = shapeElt as ShapeBpmnSemantic;
       const incomingEdges = bpmnSemantic.incomingIds;
       const outgoingEdges = bpmnSemantic.outgoingIds;
       for (const edgeId of incomingEdges) {
-        const edgeElement = this.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
-        const sourceRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).sourceRefId;
+        const edgeElement = this.bpmnElementsRegistry.getModelElementsByIds(edgeId)[0];
+        const sourceRef = (edgeElement as EdgeBpmnSemantic).sourceRefId;
         if (shapeIds.includes(sourceRef)) {
           edgeIds.add(edgeId);
         }
       }
 
       for (const edgeId of outgoingEdges) {
-        const edgeElement = this.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
-        const targetRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).targetRefId;
+        const edgeElement = this.bpmnElementsRegistry.getModelElementsByIds(edgeId)[0];
+        const targetRef = (edgeElement as EdgeBpmnSemantic).targetRefId;
         if (shapeIds.includes(targetRef)) {
           edgeIds.add(edgeId);
         }

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -23,7 +23,7 @@ export class PathResolver {
   constructor(private readonly bpmnElementsRegistry: BpmnElementsRegistry) {}
 
   /**
-   * Currently, if the shapeIds parameter contains ids related to edges, these ids are ignored and not returned as part of the visited edges.
+   * Currently, if the `shapeIds` parameter contains ids related to edges, these ids are ignored and not returned as part of the visited edges.
    *
    * @param shapeIds the ids used to compute the visited edges
    */

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -31,7 +31,7 @@ export class PathResolver {
     const edgeIds = new Set<string>();
     for (const shapeId of shapeIds) {
       const shapeElt = this.bpmnElementsRegistry.getModelElementsByIds(shapeId)[0];
-      // filter non existing element and edge
+      // filter non existing elements and edges
       if (!shapeElt?.isShape) {
         continue;
       }

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -37,7 +37,7 @@ export class PathResolver {
       outgoingIds.push(...shape.outgoingIds);
     }
 
-    // remove duplicates
+    // find edges and remove duplicates
     return [...new Set(incomingIds.filter(incomingId => outgoingIds.includes(incomingId)))];
   }
 }

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -31,7 +31,7 @@ export class PathResolver {
     const edgeIds = new Set<string>();
     for (const shapeId of shapeIds) {
       const shapeElt = this.bpmnElementsRegistry.getModelElementsByIds(shapeId)[0];
-      // filter non existing elements and edges
+      // filter non-existing elements and edges
       if (!shapeElt?.isShape) {
         continue;
       }

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -25,7 +25,7 @@ export class PathResolver {
   /**
    * Currently, if the shapeIds parameter contains ids related to edges, these ids are ignored and not returned as part of the visited edges.
    *
-   * @param shapeIds
+   * @param shapeIds the ids used to compute the visited edges
    */
   getVisitedEdges(shapeIds: string[]): string[] {
     const incomingIds = [] as string[];
@@ -37,7 +37,7 @@ export class PathResolver {
       outgoingIds.push(...shape.outgoingIds);
     }
 
-    // TODO add test to show we manage duplicates
-    return incomingIds.filter(incomingId => outgoingIds.includes(incomingId));
+    // remove duplicates
+    return [...new Set(incomingIds.filter(incomingId => outgoingIds.includes(incomingId)))];
   }
 }

--- a/packages/addons/test/fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn
@@ -23,9 +23,15 @@
     <bpmn:userTask id="Task_2" name="Task 2">
       <bpmn:incoming>Flow_Task_1_Task_2</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_2_Task_3</bpmn:outgoing>
+      <!-- extra duplicated outgoing -->
+      <bpmn:outgoing>Flow_Task_2_Task_3</bpmn:outgoing>
+      <!-- END OF extra duplicated outgoing -->
     </bpmn:userTask>
     <bpmn:serviceTask id="Task_3" name="Task 3">
       <bpmn:incoming>Flow_Task_2_Task_3</bpmn:incoming>
+      <!-- extra duplicated incoming -->
+      <bpmn:incoming>Flow_Task_2_Task_3</bpmn:incoming>
+      <!-- END OF extra duplicated incoming -->
       <bpmn:outgoing>Flow_Task_3_Task_4</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_Task_4_EndEvent_1" sourceRef="Task_4" targetRef="EndEvent_1" />

--- a/packages/addons/test/fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" name="Start event">
+      <bpmn:outgoing>Flow_StartEvent_1_Task_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" name="Task 1">
+      <bpmn:incoming>Flow_StartEvent_1_Task_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_1_Task_2</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_StartEvent_1_Task_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_Task_1_Task_2" sourceRef="Task_1" targetRef="Task_2" />
+    <bpmn:sequenceFlow id="Flow_Task_2_Task_3" sourceRef="Task_2" targetRef="Task_3" />
+    <bpmn:endEvent id="EndEvent_1" name="End event">
+      <bpmn:incoming>Flow_0ukxpir</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:userTask id="Task_2" name="Task 2">
+      <bpmn:incoming>Flow_Task_1_Task_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_2_Task_3</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask id="Task_3" name="Task 3">
+      <bpmn:incoming>Flow_Task_2_Task_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_3_Task_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0ukxpir" sourceRef="Task_4" targetRef="EndEvent_1" />
+    <bpmn:scriptTask id="Task_4" name="Task 4">
+      <bpmn:incoming>Flow_Task_3_Task_4</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ukxpir</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_Task_3_Task_4" sourceRef="Task_3" targetRef="Task_4" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="164" y="145" width="54" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="428" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_3_di" bpmnElement="Task_3">
+        <dc:Bounds x="598" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_4_di" bpmnElement="Task_4">
+        <dc:Bounds x="790" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="972" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="965" y="78" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_StartEvent_1_Task_1_di" bpmnElement="Flow_StartEvent_1_Task_1">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_1_Task_2_di" bpmnElement="Flow_Task_1_Task_2">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="428" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_3_Task_4_di" bpmnElement="Flow_Task_3_Task_4">
+        <di:waypoint x="698" y="120" />
+        <di:waypoint x="790" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_2_Task_3_di" bpmnElement="Flow_Task_2_Task_3">
+        <di:waypoint x="528" y="120" />
+        <di:waypoint x="598" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ukxpir_di" bpmnElement="Flow_0ukxpir">
+        <di:waypoint x="890" y="120" />
+        <di:waypoint x="972" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/packages/addons/test/fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn
@@ -3,6 +3,9 @@
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" name="Start event">
       <bpmn:outgoing>Flow_StartEvent_1_Task_1</bpmn:outgoing>
+      <!-- extra wrong outgoing -->
+      <bpmn:outgoing>Flow_Task_1_Task_2</bpmn:outgoing>
+      <!-- END OF extra wrong outgoing -->
     </bpmn:startEvent>
     <bpmn:task id="Task_1" name="Task 1">
       <bpmn:incoming>Flow_StartEvent_1_Task_1</bpmn:incoming>
@@ -12,7 +15,10 @@
     <bpmn:sequenceFlow id="Flow_Task_1_Task_2" sourceRef="Task_1" targetRef="Task_2" />
     <bpmn:sequenceFlow id="Flow_Task_2_Task_3" sourceRef="Task_2" targetRef="Task_3" />
     <bpmn:endEvent id="EndEvent_1" name="End event">
-      <bpmn:incoming>Flow_0ukxpir</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_4_EndEvent_1</bpmn:incoming>
+      <!-- extra wrong incoming -->
+      <bpmn:incoming>Flow_Task_3_Task_4</bpmn:incoming>
+      <!-- END OF extra wrong incoming -->
     </bpmn:endEvent>
     <bpmn:userTask id="Task_2" name="Task 2">
       <bpmn:incoming>Flow_Task_1_Task_2</bpmn:incoming>
@@ -22,10 +28,10 @@
       <bpmn:incoming>Flow_Task_2_Task_3</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_3_Task_4</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0ukxpir" sourceRef="Task_4" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_Task_4_EndEvent_1" sourceRef="Task_4" targetRef="EndEvent_1" />
     <bpmn:scriptTask id="Task_4" name="Task 4">
       <bpmn:incoming>Flow_Task_3_Task_4</bpmn:incoming>
-      <bpmn:outgoing>Flow_0ukxpir</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Task_4_EndEvent_1</bpmn:outgoing>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_Task_3_Task_4" sourceRef="Task_3" targetRef="Task_4" />
   </bpmn:process>
@@ -75,7 +81,7 @@
         <di:waypoint x="528" y="120" />
         <di:waypoint x="598" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ukxpir_di" bpmnElement="Flow_0ukxpir">
+      <bpmndi:BPMNEdge id="Flow_Task_4_EndEvent_1_di" bpmnElement="Flow_Task_4_EndEvent_1">
         <di:waypoint x="890" y="120" />
         <di:waypoint x="972" y="120" />
       </bpmndi:BPMNEdge>

--- a/packages/addons/test/fixtures/bpmn/paths/simple.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/simple.bpmn
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" name="Start event">
+      <bpmn:outgoing>Flow_17a0d5j</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" name="Task 1">
+      <bpmn:incoming>Flow_17a0d5j</bpmn:incoming>
+      <bpmn:outgoing>Flow_12pv067</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_17a0d5j" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:exclusiveGateway id="Gateway_1">
+      <bpmn:incoming>Flow_12pv067</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qsbuis</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19c1zlq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_12pv067" sourceRef="Task_1" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="Flow_1qsbuis" sourceRef="Gateway_1" targetRef="Task_2_1" />
+    <bpmn:sequenceFlow id="Flow_19c1zlq" sourceRef="Gateway_1" targetRef="Task_2_2" />
+    <bpmn:sequenceFlow id="Flow_1mbmuau" sourceRef="Task_2_2" targetRef="IntermediateEvent_1" />
+    <bpmn:exclusiveGateway id="Gateway_2">
+      <bpmn:incoming>Flow_1yaoxx4</bpmn:incoming>
+      <bpmn:incoming>Flow_112r0jv</bpmn:incoming>
+      <bpmn:outgoing>Flow_122udrp</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1yaoxx4" sourceRef="IntermediateEvent_1" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_112r0jv" sourceRef="Task_2_1" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_122udrp" sourceRef="Gateway_2" targetRef="Task_3" />
+    <bpmn:endEvent id="EndEvent_1" name="End event">
+      <bpmn:incoming>Flow_1q25pru</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1q25pru" sourceRef="Task_3" targetRef="EndEvent_1" />
+    <bpmn:userTask id="Task_2_1" name="Task 2.1">
+      <bpmn:incoming>Flow_1qsbuis</bpmn:incoming>
+      <bpmn:outgoing>Flow_112r0jv</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:scriptTask id="Task_2_2" name="Task 2.2">
+      <bpmn:incoming>Flow_19c1zlq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mbmuau</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:serviceTask id="Task_3" name="Task 3">
+      <bpmn:incoming>Flow_122udrp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q25pru</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:intermediateCatchEvent id="IntermediateEvent_1" name="Timer intermediate event">
+      <bpmn:incoming>Flow_1mbmuau</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yaoxx4</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_12w1w5x" />
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="164" y="145" width="54" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="415" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_2_di" bpmnElement="Gateway_2" isMarkerVisible="true">
+        <dc:Bounds x="765" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1032" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1025" y="145" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_1_di" bpmnElement="Task_2_1">
+        <dc:Bounds x="520" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_2_di" bpmnElement="Task_2_2">
+        <dc:Bounds x="520" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_3_di" bpmnElement="Task_3">
+        <dc:Bounds x="870" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateEvent_1_di" bpmnElement="IntermediateEvent_1">
+        <dc:Bounds x="682" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="670" y="255" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17a0d5j_di" bpmnElement="Flow_17a0d5j">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12pv067_di" bpmnElement="Flow_12pv067">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="415" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qsbuis_di" bpmnElement="Flow_1qsbuis">
+        <di:waypoint x="465" y="120" />
+        <di:waypoint x="520" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19c1zlq_di" bpmnElement="Flow_19c1zlq">
+        <di:waypoint x="440" y="145" />
+        <di:waypoint x="440" y="230" />
+        <di:waypoint x="520" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mbmuau_di" bpmnElement="Flow_1mbmuau">
+        <di:waypoint x="620" y="230" />
+        <di:waypoint x="682" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yaoxx4_di" bpmnElement="Flow_1yaoxx4">
+        <di:waypoint x="718" y="230" />
+        <di:waypoint x="790" y="230" />
+        <di:waypoint x="790" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_112r0jv_di" bpmnElement="Flow_112r0jv">
+        <di:waypoint x="620" y="120" />
+        <di:waypoint x="765" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_122udrp_di" bpmnElement="Flow_122udrp">
+        <di:waypoint x="815" y="120" />
+        <di:waypoint x="870" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q25pru_di" bpmnElement="Flow_1q25pru">
+        <di:waypoint x="970" y="120" />
+        <di:waypoint x="1032" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/packages/addons/test/fixtures/bpmn/paths/simple.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/simple.bpmn
@@ -12,18 +12,18 @@
     <bpmn:exclusiveGateway id="Gateway_1">
       <bpmn:incoming>Flow_12pv067</bpmn:incoming>
       <bpmn:outgoing>Flow_1qsbuis</bpmn:outgoing>
-      <bpmn:outgoing>Flow_19c1zlq</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_1_Task_2_2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_12pv067" sourceRef="Task_1" targetRef="Gateway_1" />
     <bpmn:sequenceFlow id="Flow_1qsbuis" sourceRef="Gateway_1" targetRef="Task_2_1" />
-    <bpmn:sequenceFlow id="Flow_19c1zlq" sourceRef="Gateway_1" targetRef="Task_2_2" />
-    <bpmn:sequenceFlow id="Flow_1mbmuau" sourceRef="Task_2_2" targetRef="IntermediateEvent_1" />
+    <bpmn:sequenceFlow id="Flow_Gateway_1_Task_2_2" sourceRef="Gateway_1" targetRef="Task_2_2" />
+    <bpmn:sequenceFlow id="Flow_Task_2_2_IntermediateEvent_1" sourceRef="Task_2_2" targetRef="IntermediateEvent_1" />
     <bpmn:exclusiveGateway id="Gateway_2">
-      <bpmn:incoming>Flow_1yaoxx4</bpmn:incoming>
+      <bpmn:incoming>Flow_IntermediateEvent_1_Gateway_2</bpmn:incoming>
       <bpmn:incoming>Flow_112r0jv</bpmn:incoming>
       <bpmn:outgoing>Flow_122udrp</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1yaoxx4" sourceRef="IntermediateEvent_1" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_IntermediateEvent_1_Gateway_2" sourceRef="IntermediateEvent_1" targetRef="Gateway_2" />
     <bpmn:sequenceFlow id="Flow_112r0jv" sourceRef="Task_2_1" targetRef="Gateway_2" />
     <bpmn:sequenceFlow id="Flow_122udrp" sourceRef="Gateway_2" targetRef="Task_3" />
     <bpmn:endEvent id="EndEvent_1" name="End event">
@@ -35,16 +35,16 @@
       <bpmn:outgoing>Flow_112r0jv</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:scriptTask id="Task_2_2" name="Task 2.2">
-      <bpmn:incoming>Flow_19c1zlq</bpmn:incoming>
-      <bpmn:outgoing>Flow_1mbmuau</bpmn:outgoing>
+      <bpmn:incoming>Flow_Gateway_1_Task_2_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_2_2_IntermediateEvent_1</bpmn:outgoing>
     </bpmn:scriptTask>
     <bpmn:serviceTask id="Task_3" name="Task 3">
       <bpmn:incoming>Flow_122udrp</bpmn:incoming>
       <bpmn:outgoing>Flow_1q25pru</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:intermediateCatchEvent id="IntermediateEvent_1" name="Timer intermediate event">
-      <bpmn:incoming>Flow_1mbmuau</bpmn:incoming>
-      <bpmn:outgoing>Flow_1yaoxx4</bpmn:outgoing>
+      <bpmn:incoming>Flow_Task_2_2_IntermediateEvent_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_IntermediateEvent_1_Gateway_2</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_12w1w5x" />
     </bpmn:intermediateCatchEvent>
   </bpmn:process>
@@ -102,16 +102,16 @@
         <di:waypoint x="465" y="120" />
         <di:waypoint x="520" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19c1zlq_di" bpmnElement="Flow_19c1zlq">
+      <bpmndi:BPMNEdge id="Flow_Gateway_1_Task_2_2_di" bpmnElement="Flow_Gateway_1_Task_2_2">
         <di:waypoint x="440" y="145" />
         <di:waypoint x="440" y="230" />
         <di:waypoint x="520" y="230" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mbmuau_di" bpmnElement="Flow_1mbmuau">
+      <bpmndi:BPMNEdge id="Flow_Task_2_2_IntermediateEvent_1_di" bpmnElement="Flow_Task_2_2_IntermediateEvent_1">
         <di:waypoint x="620" y="230" />
         <di:waypoint x="682" y="230" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1yaoxx4_di" bpmnElement="Flow_1yaoxx4">
+      <bpmndi:BPMNEdge id="Flow_IntermediateEvent_1_Gateway_2_di" bpmnElement="Flow_IntermediateEvent_1_Gateway_2">
         <di:waypoint x="718" y="230" />
         <di:waypoint x="790" y="230" />
         <di:waypoint x="790" y="145" />

--- a/packages/addons/test/fixtures/bpmn/paths/simple.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/simple.bpmn
@@ -2,13 +2,13 @@
 <bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" name="Start event">
-      <bpmn:outgoing>Flow_17a0d5j</bpmn:outgoing>
+      <bpmn:outgoing>Flow_StartEvent_1_Task_1</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:task id="Task_1" name="Task 1">
-      <bpmn:incoming>Flow_17a0d5j</bpmn:incoming>
+      <bpmn:incoming>Flow_StartEvent_1_Task_1</bpmn:incoming>
       <bpmn:outgoing>Flow_12pv067</bpmn:outgoing>
     </bpmn:task>
-    <bpmn:sequenceFlow id="Flow_17a0d5j" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_StartEvent_1_Task_1" sourceRef="StartEvent_1" targetRef="Task_1" />
     <bpmn:exclusiveGateway id="Gateway_1">
       <bpmn:incoming>Flow_12pv067</bpmn:incoming>
       <bpmn:outgoing>Flow_1qsbuis</bpmn:outgoing>
@@ -90,7 +90,7 @@
           <dc:Bounds x="670" y="255" width="61" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_17a0d5j_di" bpmnElement="Flow_17a0d5j">
+      <bpmndi:BPMNEdge id="Flow_StartEvent_1_Task_1_di" bpmnElement="Flow_StartEvent_1_Task_1">
         <di:waypoint x="209" y="120" />
         <di:waypoint x="260" y="120" />
       </bpmndi:BPMNEdge>

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -24,7 +24,9 @@ describe('getVisitedEdges', () => {
   const pathResolver = new PathResolver(bpmnVisualization.bpmnElementsRegistry);
 
   test('Passing a single flow node id', () => {
-    expect(pathResolver.getVisitedEdges(['Task_2_1'])).toEqual([]);
+    const ids = ['Task_2_1'];
+    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length); // ensure passed elements exist in the model
+    expect(pathResolver.getVisitedEdges(ids)).toEqual([]);
   });
 
   test('Passing an empty array', () => {
@@ -32,7 +34,7 @@ describe('getVisitedEdges', () => {
   });
 
   test('Passing flow node ids', () => {
-    const shapeIds = [
+    const ids = [
       // some are connected
       'Gateway_1',
       'Task_2_2',
@@ -42,16 +44,26 @@ describe('getVisitedEdges', () => {
       'StartEvent_1',
       'EndEvent_1',
     ];
-    expect(pathResolver.getVisitedEdges(shapeIds)).toEqual(['Flow_Gateway_1_Task_2_2', 'Flow_Task_2_2_IntermediateEvent_1', 'Flow_IntermediateEvent_1_Gateway_2']);
+    // TODO extract function to remove duplication and remove comment
+    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length); // ensure passed elements exist in the model
+    expect(pathResolver.getVisitedEdges(ids)).toEqual(['Flow_Gateway_1_Task_2_2', 'Flow_Task_2_2_IntermediateEvent_1', 'Flow_IntermediateEvent_1_Gateway_2']);
   });
 
-  test.skip('Passing flow node and flow ids', () => {
-    // TODO return the passed edges?
-    expect(pathResolver.getVisitedEdges([])).toBe(['ylo']);
+  test('Passing shape and edge ids', () => {
+    const ids = [
+      // shapes
+      'Task_1',
+      'StartEvent_1',
+      // edges
+      'Flow_Task_2_2_IntermediateEvent_1',
+    ];
+    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length); // ensure passed elements exist in the model
+    expect(pathResolver.getVisitedEdges([])).toEqual(['Flow_StartEvent_1_Task_1']);
   });
 
-  test.skip('Passing flow ids only', () => {
-    // TODO edge ids only --> same array
-    expect(pathResolver.getVisitedEdges([])).toBe(['ylo']);
+  test('Passing edge ids only', () => {
+    const ids = ['Flow_StartEvent_1_Task_1', 'Flow_12pv067'];
+    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length); // ensure passed elements exist in the model
+    expect(pathResolver.getVisitedEdges(ids)).toEqual([]);
   });
 });

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -13,20 +13,34 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 import { describe, expect, test } from '@jest/globals';
-import { BpmnElementsIdentifier, BpmnVisualization } from '../../src';
+import { BpmnVisualization, PathResolver } from '../../src';
 import { readFileSync } from '../shared/io-utils';
 
-describe('Identify elements', () => {
+describe('getVisitedEdges', () => {
   const bpmnVisualization = new BpmnVisualization({ container: null! });
-  bpmnVisualization.load(readFileSync('./fixtures/bpmn/search-elements.bpmn'));
-  const bpmnElementsIdentifier = new BpmnElementsIdentifier(bpmnVisualization.bpmnElementsRegistry);
+  bpmnVisualization.load(readFileSync('./fixtures/bpmn/paths/simple.bpmn'));
+  const pathResolver = new PathResolver(bpmnVisualization.bpmnElementsRegistry);
 
-  test('task', () => {
-    const taskId = 'Task_2_1';
-    expect(bpmnElementsIdentifier.isActivity(taskId)).toBeTruthy();
-    expect(bpmnElementsIdentifier.isBpmnArtifact(taskId)).toBeFalsy();
-    expect(bpmnElementsIdentifier.isEvent(taskId)).toBeFalsy();
-    expect(bpmnElementsIdentifier.isGateway(taskId)).toBeFalsy();
+  test('Passing a single flow node id', () => {
+    expect(pathResolver.getVisitedEdges(['Task_2_1'])).toEqual([]);
   });
+
+  test('Passing an empty array', () => {
+    expect(pathResolver.getVisitedEdges([])).toEqual([]);
+  });
+
+  test('Passing flow node ids', () => {
+    // some connected
+    // other not connected
+    expect(pathResolver.getVisitedEdges(['Task_2_1'])).toBe(['ylo']);
+  });
+
+  test('Passing flow node and flow ids', () => {
+    // TODO return the passed edges?
+    expect(pathResolver.getVisitedEdges([])).toBe(['ylo']);
+  });
+
+  // TODO edge ids only --> same array
 });

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { describe, expect, test } from '@jest/globals';
+import { BpmnElementsIdentifier, BpmnVisualization } from '../../src';
+import { readFileSync } from '../shared/io-utils';
+
+describe('Identify elements', () => {
+  const bpmnVisualization = new BpmnVisualization({ container: null! });
+  bpmnVisualization.load(readFileSync('./fixtures/bpmn/search-elements.bpmn'));
+  const bpmnElementsIdentifier = new BpmnElementsIdentifier(bpmnVisualization.bpmnElementsRegistry);
+
+  test('task', () => {
+    const taskId = 'Task_2_1';
+    expect(bpmnElementsIdentifier.isActivity(taskId)).toBeTruthy();
+    expect(bpmnElementsIdentifier.isBpmnArtifact(taskId)).toBeFalsy();
+    expect(bpmnElementsIdentifier.isEvent(taskId)).toBeFalsy();
+    expect(bpmnElementsIdentifier.isGateway(taskId)).toBeFalsy();
+  });
+});

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -32,15 +32,26 @@ describe('getVisitedEdges', () => {
   });
 
   test('Passing flow node ids', () => {
-    // some connected
-    // other not connected
-    expect(pathResolver.getVisitedEdges(['Task_2_1'])).toBe(['ylo']);
+    const shapeIds = [
+      // some are connected
+      'Gateway_1',
+      'Task_2_2',
+      'IntermediateEvent_1',
+      'Gateway_2',
+      // others not connected
+      'StartEvent_1',
+      'EndEvent_1',
+    ];
+    expect(pathResolver.getVisitedEdges(shapeIds)).toBe(['Flow_Gateway_1_Task_2_2', 'Flow_Task_2_2_IntermediateEvent_1', 'Flow_IntermediateEvent_1_Gateway_2']);
   });
 
-  test('Passing flow node and flow ids', () => {
+  test.skip('Passing flow node and flow ids', () => {
     // TODO return the passed edges?
     expect(pathResolver.getVisitedEdges([])).toBe(['ylo']);
   });
 
-  // TODO edge ids only --> same array
+  test.skip('Passing flow ids only', () => {
+    // TODO edge ids only --> same array
+    expect(pathResolver.getVisitedEdges([])).toBe(['ylo']);
+  });
 });

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -85,11 +85,13 @@ describe('getVisitedEdges', () => {
   });
 
   test('Using a diagram with wrong incoming and outgoing', () => {
-    //   start event  --> task 1 --> task 2 --> task 3 --> task 4 --> end event
+    // In this test, we verify the impact of wrong incoming and outgoing properties in the returned "edge ids"
+    // Model: start event  --> task 1 --> task 2 --> task 3 --> task 4 --> end event
     bpmnVisualization.load(readFileSync('./fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn'));
     const ids = [
       'Task_2',
       'Task_3',
+      // The following ids shouldn't be returned once https://github.com/process-analytics/bpmn-visualization-js/issues/2852 is implemented
       'StartEvent_1', // has extra outgoing flow from Task_1 to Task_2
       'EndEvent_1', // // has extra incoming flow from Task_3 to Task_4
     ];

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -42,7 +42,7 @@ describe('getVisitedEdges', () => {
       'StartEvent_1',
       'EndEvent_1',
     ];
-    expect(pathResolver.getVisitedEdges(shapeIds)).toBe(['Flow_Gateway_1_Task_2_2', 'Flow_Task_2_2_IntermediateEvent_1', 'Flow_IntermediateEvent_1_Gateway_2']);
+    expect(pathResolver.getVisitedEdges(shapeIds)).toEqual(['Flow_Gateway_1_Task_2_2', 'Flow_Task_2_2_IntermediateEvent_1', 'Flow_IntermediateEvent_1_Gateway_2']);
   });
 
   test.skip('Passing flow node and flow ids', () => {

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -23,9 +23,13 @@ describe('getVisitedEdges', () => {
   bpmnVisualization.load(readFileSync('./fixtures/bpmn/paths/simple.bpmn'));
   const pathResolver = new PathResolver(bpmnVisualization.bpmnElementsRegistry);
 
+  const ensureElementsExistInModel = (ids: string[]): void => {
+    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length);
+  };
+
   test('Passing a single flow node id', () => {
     const ids = ['Task_2_1'];
-    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length); // ensure passed elements exist in the model
+    ensureElementsExistInModel(ids);
     expect(pathResolver.getVisitedEdges(ids)).toEqual([]);
   });
 
@@ -44,8 +48,7 @@ describe('getVisitedEdges', () => {
       'StartEvent_1',
       'EndEvent_1',
     ];
-    // TODO extract function to remove duplication and remove comment
-    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length); // ensure passed elements exist in the model
+    ensureElementsExistInModel(ids);
     expect(pathResolver.getVisitedEdges(ids)).toEqual(['Flow_Gateway_1_Task_2_2', 'Flow_Task_2_2_IntermediateEvent_1', 'Flow_IntermediateEvent_1_Gateway_2']);
   });
 
@@ -57,13 +60,13 @@ describe('getVisitedEdges', () => {
       // edges
       'Flow_Task_2_2_IntermediateEvent_1',
     ];
-    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length); // ensure passed elements exist in the model
+    ensureElementsExistInModel(ids);
     expect(pathResolver.getVisitedEdges([])).toEqual(['Flow_StartEvent_1_Task_1']);
   });
 
   test('Passing edge ids only', () => {
     const ids = ['Flow_StartEvent_1_Task_1', 'Flow_12pv067'];
-    expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length); // ensure passed elements exist in the model
+    ensureElementsExistInModel(ids);
     expect(pathResolver.getVisitedEdges(ids)).toEqual([]);
   });
 });

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -61,7 +61,7 @@ describe('getVisitedEdges', () => {
       'Flow_Task_2_2_IntermediateEvent_1',
     ];
     ensureElementsExistInModel(ids);
-    expect(pathResolver.getVisitedEdges([])).toEqual(['Flow_StartEvent_1_Task_1']);
+    expect(pathResolver.getVisitedEdges(ids)).toEqual(['Flow_StartEvent_1_Task_1']);
   });
 
   test('Passing edge ids only', () => {

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -83,4 +83,21 @@ describe('getVisitedEdges', () => {
     ensureElementsExistInModel(ids);
     expect(pathResolver.getVisitedEdges(ids)).toEqual(['Flow_StartEvent_1_Task_1']);
   });
+
+  test('Using a diagram with wrong incoming and outgoing', () => {
+    //   start event  --> task 1 --> task 2 --> task 3 --> task 4 --> end event
+    bpmnVisualization.load(readFileSync('./fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn'));
+    const ids = [
+      'Task_2',
+      'Task_3',
+      'StartEvent_1', // has extra outgoing flow from Task_1 to Task_2
+      'EndEvent_1', // // has extra incoming flow from Task_3 to Task_4
+    ];
+    ensureElementsExistInModel(ids);
+    expect(pathResolver.getVisitedEdges(ids)).toEqual([
+      'Flow_Task_1_Task_2', // from wrong outgoing StartEvent_1
+      'Flow_Task_2_Task_3',
+      'Flow_Task_3_Task_4', // from wrong incoming EndEvent_1
+    ]);
+  });
 });

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -69,4 +69,18 @@ describe('getVisitedEdges', () => {
     ensureElementsExistInModel(ids);
     expect(pathResolver.getVisitedEdges(ids)).toEqual([]);
   });
+
+  test('Passing the same shape ids several times', () => {
+    const ids = [
+      // shapes
+      'Task_1',
+      'StartEvent_1',
+      // again
+      'StartEvent_1',
+      'Task_1',
+      'Task_1',
+    ];
+    ensureElementsExistInModel(ids);
+    expect(pathResolver.getVisitedEdges(ids)).toEqual(['Flow_StartEvent_1_Task_1']);
+  });
 });


### PR DESCRIPTION
Add several unit tests and simplify the implementation.

closes #18


```[tasklist]
### Tasks
- [x] Check if we need the code that currently check that edges really exist in the model
- [x] Refactor the implementation if possible
- [x] Add link to the bpmn-visualization issue in tests to explain why extra erroneous edge ids are returned (the test will break once `bv-experimental-add-ons` uses the new release)
```

### Notes

#### Current limitation
The current implementation doesn't filter out erroneous edge identifiers that are resolved from incorrectly defined incoming and outgoing identifiers. `bpmn-visualization` doesn't filter them out itself when it should, so I decided not to do it here but to create an issue in the `bpmn-visualization` repository instead: https://github.com/process-analytics/bpmn-visualization-js/issues/2852

Note that the old implementation didn't filter out these erroneous edge identifiers either, so there's no reason to keep it instead of switching to the new implementation.

#### All code is now fully covered by tests 🎉 

```
=============================== Coverage summary ===============================
Statements   : 100% ( 63/63 )
Branches     : 100% ( 26/26 )
Functions    : 100% ( 19/19 )
Lines        : 100% ( 62/62 )
================================================================================
```