### PR TITLE
feat: expose bpmn-visualization methods in OverlaysPlugin

### DIFF
--- a/packages/addons/src/plugins/overlays.ts
+++ b/packages/addons/src/plugins/overlays.ts
@@ -15,15 +15,18 @@ limitations under the License.
 */
 
 import type { BpmnVisualization, Plugin } from '../plugins-support';
+import type { Overlay, OverlaysRegistry } from 'bpmn-visualization';
 
-export class OverlaysPlugin implements Plugin {
+export class OverlaysPlugin implements Plugin, OverlaysRegistry {
   private readonly overlayPane: HTMLElement;
   private previousStyleDisplay?: string;
   private isVisible = true;
+  private overlaysRegistry: OverlaysRegistry;
 
   constructor(bpmnVisualization: BpmnVisualization) {
     const view = bpmnVisualization.graph.getView();
     this.overlayPane = view.getOverlayPane() as HTMLElement;
+    this.overlaysRegistry = bpmnVisualization.bpmnElementsRegistry;
   }
 
   setVisible(visible = true): void {
@@ -35,6 +38,14 @@ export class OverlaysPlugin implements Plugin {
       this.overlayPane.style.display = 'none';
       this.isVisible = false;
     }
+  }
+
+  addOverlays(bpmnElementId: string, overlays: Overlay | Overlay[]): void {
+    this.overlaysRegistry.addOverlays(bpmnElementId, overlays);
+  }
+
+  removeAllOverlays(bpmnElementId: string): void {
+    this.overlaysRegistry.removeAllOverlays(bpmnElementId);
   }
 
   getPluginId(): string {

--- a/packages/addons/test/fixtures/bpmn/paths/pools-and-message-flows.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/pools-and-message-flows.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://example.bpmn.com/schema/bpmn">
   <bpmn:collaboration id="Collaboration_122a0k4">
     <bpmn:participant id="Participant_0qsmazg" name="Pool 2" processRef="Process_1" />
     <bpmn:participant id="Participant_1qqh0so" name="Pool 3" processRef="Process_18m4at8" />

--- a/packages/addons/test/fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/simple-with-wrong-incoming-and-outgoing.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://example.bpmn.com/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" name="Start event">
       <bpmn:outgoing>Flow_StartEvent_1_Task_1</bpmn:outgoing>

--- a/packages/addons/test/fixtures/bpmn/paths/simple.bpmn
+++ b/packages/addons/test/fixtures/bpmn/paths/simple.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://example.bpmn.com/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" name="Start event">
       <bpmn:outgoing>Flow_StartEvent_1_Task_1</bpmn:outgoing>

--- a/packages/addons/test/spec/plugins/overlays.test.ts
+++ b/packages/addons/test/spec/plugins/overlays.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, expect, test } from '@jest/globals';
+import { beforeEach, describe, expect, test } from '@jest/globals';
 import { BpmnVisualization, OverlaysPlugin } from '../../../src';
 import { insertBpmnContainerWithoutId } from '../../shared/dom-utils';
 import { readFileSync } from '../../shared/io-utils';
@@ -201,7 +201,7 @@ class OverlaysExpectation {
   /* eslint-enable jest/no-standalone-expect */
 }
 
-// The real type is "class MxGraphCustomOverlay extends mxgraph.mxCellOverlay" but it is not part of the API so create a convenient matching type here{
+// The real type is "class MxGraphCustomOverlay extends mxgraph.mxCellOverlay" but it is not part of the API so create a convenient matching type here
 // class BpmnVisualizationOverlay extends mxCellOverlay {}
 // In tests in this file, we are only checking the label, so use a simple type matching the label property of the actual type.
 type BpmnVisualizationOverlay = {

--- a/packages/addons/test/spec/plugins/overlays.test.ts
+++ b/packages/addons/test/spec/plugins/overlays.test.ts
@@ -18,6 +18,8 @@ import { describe, expect, test } from '@jest/globals';
 import { BpmnVisualization, OverlaysPlugin } from '../../../src';
 import { insertBpmnContainerWithoutId } from '../../shared/dom-utils';
 import { readFileSync } from '../../shared/io-utils';
+import type { Overlay } from 'bpmn-visualization';
+import type { mxGraph, mxGraphModel } from 'mxgraph';
 
 /**
  * Information taken from bpmn-visualization QuerySelectors
@@ -168,5 +170,78 @@ describe('setVisible', () => {
     plugin.setVisible();
     plugin.setVisible(false);
     expect(new ContainersRetriever(bpmnVisualization).getOverlaysContainer()).not.toBeVisible();
+  });
+});
+
+class OverlaysExpectation {
+  private readonly model: mxGraphModel;
+  private graph: mxGraph;
+  constructor(bpmnVisualization: BpmnVisualization) {
+    this.graph = bpmnVisualization.graph;
+    this.model = bpmnVisualization.graph.model;
+  }
+
+  /* eslint-disable jest/no-standalone-expect -- util code, including expect calls */
+  expectNoOverlay(bpmnId: string): void {
+    expect(this.getOverlays(bpmnId)).toHaveLength(0);
+  }
+
+  private getOverlays(bpmnId: string): BpmnVisualizationOverlay[] {
+    const cell = this.model.getCell(bpmnId);
+    return (this.graph.getCellOverlays(cell) as unknown as BpmnVisualizationOverlay[]) ?? [];
+  }
+
+  // only verify label here, the whole implementation is tested in bpmn-visualization.
+  // here we only check that the underlying method is called.
+  expectOverlays(bpmnId: string, labels: string[]): void {
+    const overlays = this.getOverlays(bpmnId);
+    expect(overlays).toHaveLength(labels.length);
+    expect(overlays.map(overlay => overlay.label)).toEqual(labels);
+  }
+  /* eslint-enable jest/no-standalone-expect */
+}
+
+// The real type is "class MxGraphCustomOverlay extends mxgraph.mxCellOverlay" but it is not part of the API so create a convenient matching type here{
+// class BpmnVisualizationOverlay extends mxCellOverlay {}
+// In tests in this file, we are only checking the label, so use a simple type matching the label property of the actual type.
+type BpmnVisualizationOverlay = {
+  label: string;
+};
+
+function createOverlay(label: string): Overlay {
+  return { label, position: 'top-center' };
+}
+
+describe('Add and remove Overlays', () => {
+  const bpmnVisualization = new BpmnVisualization({ container: insertBpmnContainerWithoutId(), plugins: [OverlaysPlugin] });
+  const overlaysPlugin = bpmnVisualization.getPlugin<OverlaysPlugin>('overlays');
+  const overlaysExpectation = new OverlaysExpectation(bpmnVisualization);
+
+  beforeEach(() => {
+    // remove all existing overlays
+    bpmnVisualization.load(readFileSync('./fixtures/bpmn/1_pool_custom_colors_with_1_text-annotation.bpmn'));
+  });
+
+  test('Add overlays', () => {
+    overlaysExpectation.expectNoOverlay('ServiceTask_1.2');
+    overlaysPlugin.addOverlays('ServiceTask_1.2', createOverlay('overlay 1'));
+    overlaysExpectation.expectOverlays('ServiceTask_1.2', ['overlay 1']);
+  });
+
+  test('Remove overlays', () => {
+    overlaysExpectation.expectNoOverlay('Activity_1wr0s0r');
+    overlaysExpectation.expectNoOverlay('StartEvent_0av7pgo');
+
+    // Create overlays
+    overlaysPlugin.addOverlays('Activity_1wr0s0r', [createOverlay('overlay 1.1'), createOverlay('overlay 1.2'), createOverlay('overlay 1.3')]);
+    overlaysExpectation.expectOverlays('Activity_1wr0s0r', ['overlay 1.1', 'overlay 1.2', 'overlay 1.3']);
+    overlaysPlugin.addOverlays('StartEvent_0av7pgo', createOverlay('overlay 2'));
+    overlaysExpectation.expectOverlays('StartEvent_0av7pgo', ['overlay 2']);
+
+    // Remove some overlays
+    overlaysPlugin.removeAllOverlays('Activity_1wr0s0r');
+    overlaysExpectation.expectNoOverlay('Activity_1wr0s0r');
+    // still there
+    overlaysExpectation.expectOverlays('StartEvent_0av7pgo', ['overlay 2']);
   });
 });

--- a/packages/demo/src/overlays.ts
+++ b/packages/demo/src/overlays.ts
@@ -31,19 +31,18 @@ const bpmnVisualization = new BpmnVisualization({
 bpmnVisualization.load(diagram, { fit: { type: FitType.Center, margin: 20 } });
 
 // Add overlays
-const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+const overlaysPlugin = bpmnVisualization.getPlugin<OverlaysPlugin>('overlays');
 const overlayStyle = { stroke: { color: 'chartreuse' }, fill: { color: 'chartreuse' }, font: { color: 'white', size: 18 } };
 // SRM subprocess
-bpmnElementsRegistry.addOverlays('Activity_0ec8azh', { label: '123', position: 'top-center', style: overlayStyle });
+overlaysPlugin.addOverlays('Activity_0ec8azh', { label: '123', position: 'top-center', style: overlayStyle });
 // Record Service Entry Sheet
-bpmnElementsRegistry.addOverlays('Activity_06cvihl', { label: '100', position: 'top-left', style: overlayStyle });
+overlaysPlugin.addOverlays('Activity_06cvihl', { label: '100', position: 'top-left', style: overlayStyle });
 // Record Invoice Receipt
-bpmnElementsRegistry.addOverlays('Activity_1u4jwkv', { label: '123', position: 'bottom-center', style: overlayStyle });
+overlaysPlugin.addOverlays('Activity_1u4jwkv', { label: '123', position: 'bottom-center', style: overlayStyle });
 // Remove Payment Block
-bpmnElementsRegistry.addOverlays('Activity_083jf01', { label: '147', position: 'top-right', style: overlayStyle });
+overlaysPlugin.addOverlays('Activity_083jf01', { label: '147', position: 'top-right', style: overlayStyle });
 
 // Configure button to hide/show overlays
-const overlaysPlugin = bpmnVisualization.getPlugin<OverlaysPlugin>('overlays');
 let isOverlaysVisible = true;
 const overlaysVisibilityButton = document.querySelector('#btn-overlays-visibility') as HTMLButtonElement;
 const handleOverlaysVisibility = (): void => {


### PR DESCRIPTION
Introduce `OverlaysRegistry` methods in the plugin to allow complete replacement of `BpmnElementsRegistry` by the plugin with regard to overlays.

Extra: anonymize the "targetNamespace" of the BPMN diagrams used in tests

Covers #77