### PR TITLE
feat: [POC] demonstrate how to add a custom overlays plugin. Let's add overlays depending on a running status (success/error)

### DIFF
--- a/packages/demo/src/overlays.ts
+++ b/packages/demo/src/overlays.ts
@@ -24,13 +24,12 @@ import { FitType, ZoomType } from 'bpmn-visualization';
 // This is simple example of the BPMN diagram, loaded as string. The '?.raw' extension support is provided by Vite.
 // For other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
 import diagram from './assets/diagram.bpmn?raw';
-import { OverlaysByStatusPlugin } from './plugins/custom-overlays';
 
 // Instantiate BpmnVisualization, and pass the OverlaysPlugin
 const bpmnVisualization = new BpmnVisualization({
   container: 'bpmn-container',
   navigation: { enabled: true },
-  plugins: [OverlaysPlugin, OverlaysByStatusPlugin],
+  plugins: [OverlaysPlugin],
 });
 // Load the BPMN diagram defined above
 const fitOptions: FitOptions = { type: FitType.Center, margin: 20 };
@@ -76,8 +75,8 @@ overlaysVisibilityButton.addEventListener('click', () => {
 // CUSTOM CODE
 // =================================================================================================================================================================================
 // Add overlays "by status"
-const overlaysByStatusPlugin = bpmnVisualization.getPlugin<OverlaysByStatusPlugin>('overlays-by-status');
-// // SRM subprocess
-overlaysByStatusPlugin.addOverlayForSuccess('Activity_0ec8azh', 123);
+// const overlaysByStatusPlugin = bpmnVisualization.getPlugin<OverlaysByStatusPlugin>('overlays-by-status');
+// SRM subprocess
+// overlaysByStatusPlugin.addOverlayForSuccess('Activity_0ec8azh', 123);
 // Record Service Entry Sheet
-overlaysByStatusPlugin.addOverlayForError('Activity_06cvihl', 100);
+// overlaysByStatusPlugin.addOverlayForError('Activity_06cvihl', 100);

--- a/packages/demo/src/overlays.ts
+++ b/packages/demo/src/overlays.ts
@@ -24,12 +24,13 @@ import { FitType, ZoomType } from 'bpmn-visualization';
 // This is simple example of the BPMN diagram, loaded as string. The '?.raw' extension support is provided by Vite.
 // For other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
 import diagram from './assets/diagram.bpmn?raw';
+import { OverlaysByStatusPlugin } from './plugins/custom-overlays';
 
 // Instantiate BpmnVisualization, and pass the OverlaysPlugin
 const bpmnVisualization = new BpmnVisualization({
   container: 'bpmn-container',
   navigation: { enabled: true },
-  plugins: [OverlaysPlugin],
+  plugins: [OverlaysPlugin, OverlaysByStatusPlugin],
 });
 // Load the BPMN diagram defined above
 const fitOptions: FitOptions = { type: FitType.Center, margin: 20 };
@@ -75,8 +76,8 @@ overlaysVisibilityButton.addEventListener('click', () => {
 // CUSTOM CODE
 // =================================================================================================================================================================================
 // Add overlays "by status"
-// const overlaysByStatusPlugin = bpmnVisualization.getPlugin<OverlaysByStatusPlugin>('overlays-by-status');
-// SRM subprocess
-// overlaysByStatusPlugin.addOverlayForSuccess('Activity_0ec8azh', 123);
+const overlaysByStatusPlugin = bpmnVisualization.getPlugin<OverlaysByStatusPlugin>('overlays-by-status');
+// // SRM subprocess
+overlaysByStatusPlugin.addOverlayForSuccess('Activity_0ec8azh', 123);
 // Record Service Entry Sheet
-// overlaysByStatusPlugin.addOverlayForError('Activity_06cvihl', 100);
+overlaysByStatusPlugin.addOverlayForError('Activity_06cvihl', 100);

--- a/packages/demo/src/overlays.ts
+++ b/packages/demo/src/overlays.ts
@@ -24,12 +24,13 @@ import { FitType, ZoomType } from 'bpmn-visualization';
 // This is simple example of the BPMN diagram, loaded as string. The '?.raw' extension support is provided by Vite.
 // For other load methods, see https://github.com/process-analytics/bpmn-visualization-examples
 import diagram from './assets/diagram.bpmn?raw';
+import { OverlaysByStatusPlugin } from './plugins/custom-overlays';
 
 // Instantiate BpmnVisualization, and pass the OverlaysPlugin
 const bpmnVisualization = new BpmnVisualization({
   container: 'bpmn-container',
   navigation: { enabled: true },
-  plugins: [OverlaysPlugin],
+  plugins: [OverlaysPlugin, OverlaysByStatusPlugin],
 });
 // Load the BPMN diagram defined above
 const fitOptions: FitOptions = { type: FitType.Center, margin: 20 };
@@ -70,3 +71,13 @@ overlaysVisibilityButton.addEventListener('click', () => {
 (document.querySelector('.zoomBox .mainButton') as HTMLButtonElement).addEventListener('click', () => {
   bpmnVisualization.navigation.fit(fitOptions);
 });
+
+// =================================================================================================================================================================================
+// CUSTOM CODE
+// =================================================================================================================================================================================
+// Add overlays "by status"
+const overlaysByStatusPlugin = bpmnVisualization.getPlugin<OverlaysByStatusPlugin>('overlays-by-status');
+// // SRM subprocess
+overlaysByStatusPlugin.addOverlayForSuccess('Activity_0ec8azh', 123);
+// Record Service Entry Sheet
+overlaysByStatusPlugin.addOverlayForError('Activity_06cvihl', 100);

--- a/packages/demo/src/plugins/custom-overlays.ts
+++ b/packages/demo/src/plugins/custom-overlays.ts
@@ -28,27 +28,27 @@ export class OverlaysByStatusPlugin implements Plugin {
     return 'overlays-by-status';
   }
 
-  addOverlayForSuccess(bpmnElementId: string, executionCount: number): void {
-    this.overlaysRegistry.addOverlays(bpmnElementId, {
-      position: 'top-left',
-      label: `${executionCount}`,
-      style: {
-        font: { color: 'white', size: 24 },
-        fill: { color: 'DarkSeaGreen' },
-        stroke: { color: 'DarkSeaGreen', width: 2 },
-      },
-    });
-  }
-
-  addOverlayForError(bpmnElementId: string, executionCount: number): void {
-    this.overlaysRegistry.addOverlays(bpmnElementId, {
-      position: 'top-right',
-      label: `${executionCount}`,
-      style: {
-        font: { color: 'white', size: 28 },
-        fill: { color: 'Red' },
-        stroke: { color: 'Red', width: 2 },
-      },
-    });
-  }
+  // addOverlayForSuccess(bpmnElementId: string, executionCount: number): void {
+  //   this.overlaysRegistry.addOverlays(bpmnElementId, {
+  //     position: 'top-left',
+  //     label: `${executionCount}`,
+  //     style: {
+  //       font: { color: 'white', size: 24 },
+  //       fill: { color: 'DarkSeaGreen' },
+  //       stroke: { color: 'DarkSeaGreen', width: 2 },
+  //     },
+  //   });
+  // }
+  //
+  // addOverlayForError(bpmnElementId: string, executionCount: number): void {
+  //   this.overlaysRegistry.addOverlays(bpmnElementId, {
+  //     position: 'top-right',
+  //     label: `${executionCount}`,
+  //     style: {
+  //       font: { color: 'white', size: 28 },
+  //       fill: { color: 'Red' },
+  //       stroke: { color: 'Red', width: 2 },
+  //     },
+  //   });
+  // }
 }

--- a/packages/demo/src/plugins/custom-overlays.ts
+++ b/packages/demo/src/plugins/custom-overlays.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import type { BpmnVisualization, Plugin } from '@process-analytics/bv-experimental-add-ons';
 import type { OverlaysRegistry } from 'bpmn-visualization';
 
-export class OverlaysByPlugin implements Plugin {
+export class OverlaysByStatusPlugin implements Plugin {
   private readonly overlaysRegistry: OverlaysRegistry;
 
   constructor(bpmnVisualization: BpmnVisualization) {
@@ -26,5 +26,29 @@ export class OverlaysByPlugin implements Plugin {
 
   getPluginId(): string {
     return 'overlays-by-status';
+  }
+
+  addOverlayForSuccess(bpmnElementId: string, executionCount: number): void {
+    this.overlaysRegistry.addOverlays(bpmnElementId, {
+      position: 'top-left',
+      label: `${executionCount}`,
+      style: {
+        font: { color: 'white', size: 24 },
+        fill: { color: 'DarkSeaGreen' },
+        stroke: { color: 'DarkSeaGreen', width: 2 },
+      },
+    });
+  }
+
+  addOverlayForError(bpmnElementId: string, executionCount: number): void {
+    this.overlaysRegistry.addOverlays(bpmnElementId, {
+      position: 'top-right',
+      label: `${executionCount}`,
+      style: {
+        font: { color: 'white', size: 28 },
+        fill: { color: 'Red' },
+        stroke: { color: 'Red', width: 2 },
+      },
+    });
   }
 }

--- a/packages/demo/src/plugins/custom-overlays.ts
+++ b/packages/demo/src/plugins/custom-overlays.ts
@@ -28,27 +28,27 @@ export class OverlaysByStatusPlugin implements Plugin {
     return 'overlays-by-status';
   }
 
-  // addOverlayForSuccess(bpmnElementId: string, executionCount: number): void {
-  //   this.overlaysRegistry.addOverlays(bpmnElementId, {
-  //     position: 'top-left',
-  //     label: `${executionCount}`,
-  //     style: {
-  //       font: { color: 'white', size: 24 },
-  //       fill: { color: 'DarkSeaGreen' },
-  //       stroke: { color: 'DarkSeaGreen', width: 2 },
-  //     },
-  //   });
-  // }
-  //
-  // addOverlayForError(bpmnElementId: string, executionCount: number): void {
-  //   this.overlaysRegistry.addOverlays(bpmnElementId, {
-  //     position: 'top-right',
-  //     label: `${executionCount}`,
-  //     style: {
-  //       font: { color: 'white', size: 28 },
-  //       fill: { color: 'Red' },
-  //       stroke: { color: 'Red', width: 2 },
-  //     },
-  //   });
-  // }
+  addOverlayForSuccess(bpmnElementId: string, executionCount: number): void {
+    this.overlaysRegistry.addOverlays(bpmnElementId, {
+      position: 'top-left',
+      label: `${executionCount}`,
+      style: {
+        font: { color: 'white', size: 24 },
+        fill: { color: 'DarkSeaGreen' },
+        stroke: { color: 'DarkSeaGreen', width: 2 },
+      },
+    });
+  }
+
+  addOverlayForError(bpmnElementId: string, executionCount: number): void {
+    this.overlaysRegistry.addOverlays(bpmnElementId, {
+      position: 'top-right',
+      label: `${executionCount}`,
+      style: {
+        font: { color: 'white', size: 28 },
+        fill: { color: 'Red' },
+        stroke: { color: 'Red', width: 2 },
+      },
+    });
+  }
 }

--- a/packages/demo/src/plugins/custom-overlays.ts
+++ b/packages/demo/src/plugins/custom-overlays.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { BpmnVisualization, Plugin } from '@process-analytics/bv-experimental-add-ons';
+import type { OverlaysRegistry } from 'bpmn-visualization';
+
+export class OverlaysByPlugin implements Plugin {
+  private readonly overlaysRegistry: OverlaysRegistry;
+
+  constructor(bpmnVisualization: BpmnVisualization) {
+    this.overlaysRegistry = bpmnVisualization.bpmnElementsRegistry;
+  }
+
+  getPluginId(): string {
+    return 'overlays-by-status';
+  }
+}


### PR DESCRIPTION
**DISCLAIMER: this is a poc, so it is not intended to be merged. Please do not push in the branch**

This is for demonstration purpose only.
Content
- introduce a custom overlays plugin
- provide 2 methods to add an overlay if the status of the BPMN element is success or error
- the 2 methods let specify an execution count as a number. Label have to be defined as string when using the regular overlay APIs