### PR TITLE
refactor(path): let `bpmn-visualization` filters duplicates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3140,12 +3140,12 @@
       }
     },
     "node_modules/bpmn-visualization": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-0.41.0.tgz",
-      "integrity": "sha512-v8hb50/4VgOu6gUxrGgNnhD4JgD0+qvPfmbKLgt1u94QliM08AkMm/IeZvuvA7bH4F1D2HFn+M+dwV/3BbLqDw==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/bpmn-visualization/-/bpmn-visualization-0.42.0.tgz",
+      "integrity": "sha512-ufOP7AWdy2fDqcHndCYwp8rdEcsddK2PePM/r0vbLkYxYJNyZmbJPSghDwP/ab1/ghmKV2iGmGlRBOWx0IYZnQ==",
       "dependencies": {
         "@typed-mxgraph/typed-mxgraph": "~1.0.8",
-        "fast-xml-parser": "4.3.1",
+        "fast-xml-parser": "4.3.2",
         "lodash-es": "~4.17.21",
         "mxgraph": "4.2.2",
         "strnum": "1.0.5"
@@ -5353,17 +5353,17 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.1.tgz",
-      "integrity": "sha512-viVv3xb8D+SiS1W4cv4tva3bni08kAkx0gQnWrykMM8nXPc1FxqZPU00dCEVjkiCg4HoXd2jC4x29Nzg/l2DAA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
+      "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
       "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "dependencies": {
@@ -11970,7 +11970,7 @@
         "ts-jest": "~29.1.1"
       },
       "peerDependencies": {
-        "bpmn-visualization": ">=0.40.0"
+        "bpmn-visualization": ">=0.42.0"
       }
     },
     "packages/check-ts-support": {
@@ -11995,7 +11995,7 @@
     "packages/demo": {
       "name": "bv-addons-demo",
       "dependencies": {
-        "bpmn-visualization": "~0.41.0"
+        "bpmn-visualization": "~0.42.0"
       },
       "devDependencies": {
         "vite": "~4.4.11"

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -44,7 +44,7 @@
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --runInBand"
   },
   "peerDependencies": {
-    "bpmn-visualization": ">=0.40.0"
+    "bpmn-visualization": ">=0.42.0"
   },
   "devDependencies": {
     "@jest/globals": "~29.7.0",

--- a/packages/addons/src/paths.ts
+++ b/packages/addons/src/paths.ts
@@ -16,9 +16,6 @@ limitations under the License.
 
 import type { EdgeBpmnSemantic, ElementsRegistry, ShapeBpmnSemantic } from 'bpmn-visualization';
 
-// bpmn-visualization does not filter duplicates when passing an ids several times
-const filterDuplicates = (ids: string[]): string[] => [...new Set(ids)];
-
 const inferEdgeIds = (shapes: ShapeBpmnSemantic[]): string[] => {
   const incomingIds: string[] = [];
   const outgoingIds: string[] = [];
@@ -45,7 +42,7 @@ export class PathResolver {
    * @param shapeIds the ids used to compute the visited edges
    */
   getVisitedEdges(shapeIds: string[]): string[] {
-    const shapes = this.elementsRegistry.getModelElementsByIds(filterDuplicates(shapeIds)).filter(element => element.isShape) as ShapeBpmnSemantic[];
+    const shapes = this.elementsRegistry.getModelElementsByIds(shapeIds).filter(element => element.isShape) as ShapeBpmnSemantic[];
     return inferEdgeIds(shapes);
   }
 }
@@ -59,7 +56,7 @@ export class CasePathResolver {
   constructor(private readonly elementsRegistry: ElementsRegistry) {}
 
   compute(input: CasePathResolverInput): CasePathResolverOutput {
-    const completedElements = this.elementsRegistry.getModelElementsByIds(filterDuplicates(input.completedIds));
+    const completedElements = this.elementsRegistry.getModelElementsByIds(input.completedIds);
 
     const completedShapes = completedElements.filter(element => element.isShape) as ShapeBpmnSemantic[];
     const completedEdges = completedElements.filter(element => !element.isShape) as EdgeBpmnSemantic[];
@@ -72,7 +69,7 @@ export class CasePathResolver {
 
     // infer shapes from edges
     const computedCompletedShapeIds = completedEdges.flatMap(edge => [edge.sourceRefId, edge.targetRefId]).filter(id => !inputElementIds.has(id));
-    const computedCompletedShapes = this.elementsRegistry.getModelElementsByIds(filterDuplicates(computedCompletedShapeIds)) as ShapeBpmnSemantic[];
+    const computedCompletedShapes = this.elementsRegistry.getModelElementsByIds(computedCompletedShapeIds) as ShapeBpmnSemantic[];
 
     return {
       provided: {

--- a/packages/addons/test/spec/paths.test.ts
+++ b/packages/addons/test/spec/paths.test.ts
@@ -25,7 +25,8 @@ import { readFileSync } from '../shared/io-utils';
 
 const bpmnVisualization = createNewBpmnVisualizationWithoutContainer();
 const ensureElementsExistInModel = (ids: string[]): void => {
-  expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(ids.length);
+  const uniqueIds = [...new Set(ids)];
+  expect(bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(ids)).toHaveLength(uniqueIds.length);
 };
 
 describe('PathResolver', () => {

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --base ./"
   },
   "dependencies": {
-    "bpmn-visualization": "~0.41.0"
+    "bpmn-visualization": "~0.42.0"
   },
   "devDependencies": {
     "vite": "~4.4.11"


### PR DESCRIPTION
The `ElementsRegistry` methods now filter duplicates since version 0.42.0. As a result, the filtering performed here can now be removed.

Important change: bv-experimental-add-ons now requires `bpmn-visualization` 0.42.0.

Closes #150