### PR TITLE
docs: present the library as less "experimental" than before

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">bpmn-visualization experimental add-ons</h1>
+<h1 align="center">bpmn-visualization add-ons</h1>
 <div align="center">
     <p align="center"> 
         <a href="https://npmjs.org/package/@process-analytics/bv-experimental-add-ons">
@@ -27,16 +27,14 @@
 </div>  
 <br>
 
-Experimental add-ons for [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js).
 
+## 🔆 Presentation
 
-## 🔆 Project Status
+`bv-experimental-add-ons` offers new functionalities to [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js) in the form of add-ons.
 
-`bv-experimental-add-ons` is at an early stage of development.
-
-It provides new experimental features for `bpmn-visualization`.
-
+`bv-experimental-add-ons` is being actively developed.
 Before the release of version `1.0.0`, there may be some breaking changes.
+
 <!--
 We avoid these as much as possible, and carefully document them in the release notes.
 As far as possible, we maintain compatibility for some minor versions.

--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -1,6 +1,6 @@
-# bpmn-visualization experimental add-ons
+# bpmn-visualization add-ons
 
-Experimental add-ons for [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js).
+`bv-experimental-add-ons` offers new functionalities to [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js) in the form of add-ons.
 
 
 ## 📌 Usage

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -1,4 +1,4 @@
-# Demo for "bpmn-visualization experimental add-ons"
+# Demo for "bpmn-visualization add-ons"
 
 The demo has been initialized using [bpmn-visualization-demo-template](https://github.com/process-analytics/bpmn-visualization-demo-template/).
 

--- a/packages/demo/index.html
+++ b/packages/demo/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/assets/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>bv-experimental-add-ons</title>
+    <title>bpmn-visualization add-ons</title>
     <link rel="stylesheet" href="/src/assets/index.css" type="text/css">
 </head>
 <body>
 <header>
     <img src="/assets/logo.svg" id="logo" alt="The Process Analytics project logo" class="logo">
-    <h1>bv-experimental-add-ons</h1>
+    <h1>bpmn-visualization add-ons</h1>
 </header>
 <section class="presentation">
-    Welcome to <code>bv-experimental-add-ons</code>.
+    Welcome to <code>bpmn-visualization add-ons</code>.
     <p>
-    <code>bv-experimental-add-ons</code> provides new experimental features for <a href="https://github.com/process-analytics/bpmn-visualization-js" target="_blank" rel="noopener">bpmn-visualization</a>.
+    It provides new features for <a href="https://github.com/process-analytics/bpmn-visualization-js" target="_blank" rel="noopener">bpmn-visualization</a>.
     <p>
 
     <div class="source-code">


### PR DESCRIPTION
We received several comments indicating that the term "experimental" might prevent people from evaluating the library. They might see it as being at too early a stage of development.

We want to increase the dissemination and use of the library as much as possible. That's why we've removed the word "experimental" from the wording.