### PR TITLE
chore(dev-deps): bump typescript from 5.2.2 to 5.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "husky": "~8.0.3",
         "lint-staged": "~15.1.0",
         "npm-run-all": "~4.1.5",
-        "typescript": "~5.2.2"
+        "typescript": "~5.3.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -11551,9 +11551,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "husky": "~8.0.3",
     "lint-staged": "~15.1.0",
     "npm-run-all": "~4.1.5",
-    "typescript": "~5.2.2"
+    "typescript": "~5.3.2"
   },
   "lint-staged": {
     "*.{js,cjs,mjs,ts,cts,mts}": [


### PR DESCRIPTION
### Resources

Announce on `2023-11-20`: https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/