### PR TITLE
ci: add "actions" permissions to fix GH Pages deploy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -44,6 +44,7 @@ jobs:
       contents: read
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
+      actions: read # to download an artifact uploaded by `actions/upload-pages-artifact@v3`
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The deployment of 395c856468ac9b3ce603ad8f9d6368e842e68f74 failed after bumping actions/deploy-pages from 3 to 4.

This new version of the action requires GH_TOKEN to have a new permission. This point was not documented at the time the action was bumped.

### Notes

Adding this new permission has been successfully tested in the playground repository, see https://github.com/process-analytics/bv-experimental-add-ons/commit/395c856468ac9b3ce603ad8f9d6368e842e68f74#commitcomment-135507566.