### PR TITLE
feat: introduce `StyleByNamePlugin`

### DIFF
--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -24,6 +24,13 @@ The `@process-analytics/bv-experimental-add-ons` npm package includes type defin
 
 The plugins infrastructure provides a way to register extension points.
 
+Important (to continue)
+```diff
+- import {BpmnVisualization} from "bpmn-visualization";
++ import {BpmnVisualization} from "@process-analytics/bv-experimental-add-ons";
+```
+
+
 Example of use:
 
 ```ts
@@ -45,6 +52,8 @@ myPlugin.aMethod();
 - `OverlaysPlugin`:
   - let show/hide overlays created with `BpmnElementsRegistry.addOverlays`.
   - provides all `BpmnElementsRegistry` methods relating to overlays.
+- `StyleByNamePlugin`: provides all `BpmnElementsRegistry` methods relating to style, identifying the BPMN elements by name.
+
 
 #### Writing a custom plugin
 
@@ -84,7 +93,6 @@ Limitations
 `BpmnElementsSearcher` also provides a method to retrieve the whole BpmnSemantic objects.
 
 In this case, it allows to provide ways to choose the elements if there are several matches for a given name. See `DeduplicateNamesOptions` for more details.
-
 
 
 ### Available implementations for `Path Resolution`

--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -24,17 +24,16 @@ The `@process-analytics/bv-experimental-add-ons` npm package includes type defin
 
 The plugins infrastructure provides a way to register extension points.
 
-Important (to continue)
+> [!IMPORTANT]  
+> To be able to register and use the plugins, you need to import `BpmnVisualization` from the `addons` package, and not from `bpmn-visualization`.
 ```diff
 - import {BpmnVisualization} from "bpmn-visualization";
 + import {BpmnVisualization} from "@process-analytics/bv-experimental-add-ons";
 ```
 
-
 Example of use:
 
 ```ts
-// use BpmnVisualization from addons not from bpmn-visualization
 import {BpmnVisualization} from "@process-analytics/bv-experimental-add-ons";
 
 const bpmnVisualization = new BpmnVisualization({

--- a/packages/addons/src/plugins/index.ts
+++ b/packages/addons/src/plugins/index.ts
@@ -16,3 +16,4 @@ limitations under the License.
 
 export * from './elements';
 export * from './overlays';
+export * from './style';

--- a/packages/addons/src/plugins/style.ts
+++ b/packages/addons/src/plugins/style.ts
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { BpmnVisualization, Plugin } from '../plugins-support';
+import type { StyleRegistry, StyleUpdate } from 'bpmn-visualization';
+
+import { BpmnElementsSearcher } from '../bpmn-elements';
+
+export interface StyleRegistryByName extends StyleRegistry {
+  /**
+   * Update the style of the BPMN elements with the given names.
+   *
+   * See {@link StyleRegistry.updateStyle} for more details.
+   *
+   * @param bpmnElementNames The name of the BPMN element(s) whose style must be updated.
+   * @param styleUpdate The style properties to update.
+   */
+  updateStyle(bpmnElementNames: string | string[], styleUpdate: StyleUpdate): void;
+
+  /**
+   * Reset the style of the BPMN elements with the given names.
+   *
+   * See {@link StyleRegistry.resetStyle} for more details.
+   *
+   * @param bpmnElementNames The name of the BPMN element(s) whose style must be reset. When passing a nullish parameter, the style of all BPMN elements will be reset. Passing an empty array has no effect.
+   */
+  resetStyle(bpmnElementNames?: string | string[]): void;
+}
+
+/**
+ * Provide style operations on BPMN elements, identifying them by name.
+ *
+ * This plugin is a wrapper that delegates the actual style operations to {@link StyleRegistry}. It uses the {@link BpmnElementsSearcher} to map names to ids.
+ *
+ * **IMPORTANT**: The mapping is currently not cached, nor pre-fetched after the BPMN source has been loaded.
+ * So the implementation is not very effective. Caching and pre-fetch features will be implemented in the future.
+ * See https://github.com/process-analytics/bv-experimental-add-ons/issues/4 for improvement.
+ */
+export class StyleByNamePlugin implements Plugin, StyleRegistryByName {
+  private readonly searcher: BpmnElementsSearcher;
+  private readonly styleRegistry: StyleRegistry;
+
+  constructor(bpmnVisualization: BpmnVisualization) {
+    this.searcher = new BpmnElementsSearcher(bpmnVisualization.bpmnElementsRegistry);
+    this.styleRegistry = bpmnVisualization.bpmnElementsRegistry;
+  }
+
+  getPluginId(): string {
+    return 'style-by-name';
+  }
+
+  updateStyle(bpmnElementNames: string | string[], styleUpdate: StyleUpdate): void {
+    const bpmnElements = this.searcher.getElementsByNames(bpmnElementNames as Array<string>);
+    this.styleRegistry.updateStyle(
+      bpmnElements.map(bpmnElement => bpmnElement.id),
+      styleUpdate,
+    );
+  }
+
+  resetStyle(bpmnElementNames?: string | string[]): void {
+    if (!bpmnElementNames) {
+      this.styleRegistry.resetStyle();
+      return;
+    }
+    const bpmnElements = this.searcher.getElementsByNames(bpmnElementNames as Array<string>);
+    this.styleRegistry.resetStyle(bpmnElements.map(bpmnElement => bpmnElement.id));
+  }
+}

--- a/packages/addons/test/spec/plugins/elements.test.ts
+++ b/packages/addons/test/spec/plugins/elements.test.ts
@@ -17,8 +17,7 @@ limitations under the License.
 import { describe, expect, test } from '@jest/globals';
 import { ShapeBpmnElementKind, ShapeBpmnEventDefinitionKind, type ShapeBpmnSemantic } from 'bpmn-visualization';
 
-import { BpmnVisualization } from '../../../src';
-import { ElementsPlugin } from '../../../src/plugins/elements';
+import { BpmnVisualization, ElementsPlugin } from '../../../src';
 import { insertBpmnContainerWithoutId } from '../../shared/dom-utils';
 import { readFileSync } from '../../shared/io-utils';
 

--- a/packages/addons/test/spec/plugins/style.test.ts
+++ b/packages/addons/test/spec/plugins/style.test.ts
@@ -84,7 +84,6 @@ describe('StyleByNamePlugin', () => {
     });
   });
 
-  // TODO Add the same test for resetStyle + a test when passing undefined or no parameter
   describe('resetStyle', () => {
     test('Pass a single name related to an existing element', () => {
       styleByNamePlugin.resetStyle('gateway 2');

--- a/packages/addons/test/spec/plugins/style.test.ts
+++ b/packages/addons/test/spec/plugins/style.test.ts
@@ -1,0 +1,142 @@
+/*
+Copyright 2024 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { BpmnElementsRegistry } from 'bpmn-visualization';
+
+import { BpmnVisualization, StyleByNamePlugin } from '../../../src';
+import { insertBpmnContainerWithoutId } from '../../shared/dom-utils';
+import { readFileSync } from '../../shared/io-utils';
+
+// jest mock configuration
+const mockBvResetStyleByIds = jest.spyOn(BpmnElementsRegistry.prototype, 'resetStyle');
+const mockBvUpdateStyleByIds = jest.spyOn(BpmnElementsRegistry.prototype, 'updateStyle');
+
+beforeEach(() => {
+  mockBvResetStyleByIds.mockClear();
+  mockBvUpdateStyleByIds.mockClear();
+});
+
+// The actual implementation is in `bpmn-visualization`. Here, we only validate that the `bpmn-visualization` code is called.
+describe('StyleByNamePlugin', () => {
+  const bpmnVisualization = new BpmnVisualization({ container: insertBpmnContainerWithoutId(), plugins: [StyleByNamePlugin] });
+  bpmnVisualization.load(readFileSync('./fixtures/bpmn/search-elements.bpmn'));
+  const styleByNamePlugin = bpmnVisualization.getPlugin<StyleByNamePlugin>('style-by-name');
+
+  describe('updateStyle', () => {
+    test('Pass a single name related to an existing element', () => {
+      styleByNamePlugin.updateStyle('gateway 2', { stroke: { color: 'red' } });
+
+      // 'gateway 2' name is for id 'Gateway_0t7d2lu'
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledWith(['Gateway_0t7d2lu'], { stroke: { color: 'red' } });
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass several names related to existing elements', () => {
+      styleByNamePlugin.updateStyle(['task 2.2', 'gateway 2'], { fill: { color: 'chartreuse' }, stroke: { width: 2 } });
+
+      // 'task 2.2' name is for id 'Activity_08z13ne'
+      // 'gateway 2' name is for id 'Gateway_0t7d2lu'
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledWith(['Activity_08z13ne', 'Gateway_0t7d2lu'], { fill: { color: 'chartreuse' }, stroke: { width: 2 } });
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass an empty array', () => {
+      styleByNamePlugin.updateStyle([], { fill: { opacity: 50 } });
+
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledWith([], { fill: { opacity: 50 } });
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass a single name NOT related to an existing element', () => {
+      styleByNamePlugin.updateStyle('no_exist', { opacity: 30 });
+
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledWith([], { opacity: 30 });
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass several names NOT related to existing elements', () => {
+      styleByNamePlugin.updateStyle(['no_exist_1', 'no_exist_2'], { opacity: 30 });
+
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledWith([], { opacity: 30 });
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass several names, some related to existing elements, some NOT related to existing elements', () => {
+      styleByNamePlugin.updateStyle(['no_exist_1', 'gateway 1', 'no_exist_2'], { opacity: 30 });
+
+      // 'gateway 1' name is for id 'Gateway_1'
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledWith(['Gateway_1'], { opacity: 30 });
+      expect(mockBvUpdateStyleByIds).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // TODO Add the same test for resetStyle + a test when passing undefined or no parameter
+  describe('resetStyle', () => {
+    test('Pass a single name related to an existing element', () => {
+      styleByNamePlugin.resetStyle('gateway 2');
+
+      // 'gateway 2' name is for id 'Gateway_0t7d2lu'
+      expect(mockBvResetStyleByIds).toHaveBeenCalledWith(['Gateway_0t7d2lu']);
+      expect(mockBvResetStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass several names related to existing elements', () => {
+      styleByNamePlugin.resetStyle(['task 2.2', 'gateway 2']);
+
+      // 'task 2.2' name is for id 'Activity_08z13ne'
+      // 'gateway 2' name is for id 'Gateway_0t7d2lu'
+      expect(mockBvResetStyleByIds).toHaveBeenCalledWith(['Activity_08z13ne', 'Gateway_0t7d2lu']);
+      expect(mockBvResetStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass an empty array', () => {
+      styleByNamePlugin.resetStyle([]);
+
+      expect(mockBvResetStyleByIds).toHaveBeenCalledWith([]);
+      expect(mockBvResetStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass a single name NOT related to an existing element', () => {
+      styleByNamePlugin.resetStyle('no_exist');
+
+      expect(mockBvResetStyleByIds).toHaveBeenCalledWith([]);
+      expect(mockBvResetStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass several names NOT related to existing elements', () => {
+      styleByNamePlugin.resetStyle(['no_exist_1', 'no_exist_2']);
+
+      expect(mockBvResetStyleByIds).toHaveBeenCalledWith([]);
+      expect(mockBvResetStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass several names, some related to existing elements, some NOT related to existing elements', () => {
+      styleByNamePlugin.resetStyle(['no_exist_1', 'gateway 1', 'no_exist_2']);
+
+      // 'gateway 1' name is for id 'Gateway_1'
+      expect(mockBvResetStyleByIds).toHaveBeenCalledWith(['Gateway_1']);
+      expect(mockBvResetStyleByIds).toHaveBeenCalledTimes(1);
+    });
+
+    test('Pass nullish parameter', () => {
+      styleByNamePlugin.resetStyle();
+
+      expect(mockBvResetStyleByIds).toHaveBeenCalledWith();
+      expect(mockBvResetStyleByIds).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Provide the same API as `StyleRegistry` but pass names instead of ids to identify BPMN elements.

NOTE: To map names to ids, the plugin uses `BpmnElementsSearcher`.
The mapping is currently not cached, nor pre-fetched after the BPMN source has been loaded.
So the implementation is not very effective. Caching and pre-fetch features will be implemented in
the future.

## Notes

Closes #75
There is no demo of this plugin for now, it will be done as part of #78.
