### PR TITLE
feat(type): add guidance to retrieve core plugins

### DIFF
--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -57,6 +57,14 @@ export type PluginOptionExtension = {
 
 export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
 
+/**
+ * The plugins provided by `bv-experimental-add-ons`.
+ *
+ * @since 0.7.0
+ */
+// TODO review the type name
+export type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-by-name';
+
 export class BpmnVisualization extends BaseBpmnVisualization {
   private readonly plugins: Map<string, Plugin> = new Map();
 
@@ -65,7 +73,7 @@ export class BpmnVisualization extends BaseBpmnVisualization {
     this.registerPlugins(options);
   }
 
-  getPlugin<T extends Plugin>(id: string): T {
+  getPlugin<T extends Plugin>(id: DefaultPlugins | string): T {
     return this.plugins.get(id) as T;
   }
 

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -64,8 +64,14 @@ export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
  */
 // TODO review the type name
 type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-by-name';
-type AdditionalPlugins = Exclude<string, DefaultPlugins>;
-export type PluginIds = DefaultPlugins | AdditionalPlugins;
+// type AdditionalPlugins = Exclude<string, DefaultPlugins>;
+// export type PluginIds = DefaultPlugins | AdditionalPlugins;
+
+export type PluginIds = DefaultPlugins | (string & Record<never, never>);
+
+// type WithReserved<T, R> = T & (T extends R ? never : T);
+// export type PluginIds = WithReserved<string, DefaultPlugins>;
+// type NotDefaultPlugins<T> = T extends DefaultPlugins ? never : T;
 
 export class BpmnVisualization extends BaseBpmnVisualization {
   private readonly plugins: Map<string, Plugin> = new Map();

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -64,7 +64,7 @@ export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
  */
 // TODO review the type name
 export type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-by-name';
-export type PluginIds = DefaultPlugins | (string & {});
+export type PluginIds = DefaultPlugins & string;
 
 export class BpmnVisualization extends BaseBpmnVisualization {
   private readonly plugins: Map<string, Plugin> = new Map();

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -58,20 +58,15 @@ export type PluginOptionExtension = {
 export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
 
 /**
- * The plugins provided by `bv-experimental-add-ons`.
- *
+ * The identifiers of the plugins provided by `bv-experimental-add-ons`.
  * @since 0.7.0
  */
-// TODO review the type name
-type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-by-name';
-// type AdditionalPlugins = Exclude<string, DefaultPlugins>;
-// export type PluginIds = DefaultPlugins | AdditionalPlugins;
-
+export type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-by-name';
+/**
+ * All possible identifiers that can be used to identify a plugin.
+ * @since 0.7.0
+ */
 export type PluginIds = DefaultPlugins | (string & Record<never, never>);
-
-// type WithReserved<T, R> = T & (T extends R ? never : T);
-// export type PluginIds = WithReserved<string, DefaultPlugins>;
-// type NotDefaultPlugins<T> = T extends DefaultPlugins ? never : T;
 
 export class BpmnVisualization extends BaseBpmnVisualization {
   private readonly plugins: Map<string, Plugin> = new Map();

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -63,8 +63,9 @@ export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
  * @since 0.7.0
  */
 // TODO review the type name
-export type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-by-name';
-export type PluginIds = DefaultPlugins & string;
+type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-by-name';
+type AdditionalPlugins = Exclude<string, DefaultPlugins>;
+export type PluginIds = DefaultPlugins | AdditionalPlugins;
 
 export class BpmnVisualization extends BaseBpmnVisualization {
   private readonly plugins: Map<string, Plugin> = new Map();

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -64,6 +64,7 @@ export type GlobalOptions = BaseGlobalOptions & PluginOptionExtension;
  */
 // TODO review the type name
 export type DefaultPlugins = 'css' | 'elements' | 'overlays' | 'style' | 'style-by-name';
+export type PluginIds = DefaultPlugins | (string & {});
 
 export class BpmnVisualization extends BaseBpmnVisualization {
   private readonly plugins: Map<string, Plugin> = new Map();
@@ -73,7 +74,7 @@ export class BpmnVisualization extends BaseBpmnVisualization {
     this.registerPlugins(options);
   }
 
-  getPlugin<T extends Plugin>(id: DefaultPlugins | string): T {
+  getPlugin<T extends Plugin>(id: PluginIds): T {
     return this.plugins.get(id) as T;
   }
 


### PR DESCRIPTION
When calling the `getPlugin` method, provide type assistance to let users know which identifiers are available to access plugins provided by `bv-experimental-add-ons`.

