### PR TITLE
fix(demo): add CSS rules removed by mistake

### DIFF
--- a/packages/demo/src/assets/index.css
+++ b/packages/demo/src/assets/index.css
@@ -20,3 +20,17 @@ body {
     margin-left: 2rem;
     margin-top: .5rem;
 }
+
+.source-code {
+  display: flex;
+  align-items: center;
+}
+
+.gh-logo {
+  display: flex;
+  text-decoration: none;
+  margin-left: .5rem;
+}
+.gh-logo img {
+  width: 2rem;
+}


### PR DESCRIPTION
They had been removed during the refactoring applied in 983841ec.


## Screenshots

before | now
---- | ----
![01_before](https://github.com/user-attachments/assets/4d6f5a2b-5fcd-44a1-bed3-68144570b22d) | ![02_now](https://github.com/user-attachments/assets/c355c8d1-c971-4db3-8ecc-7dd406f9bf78)


