### PR TITLE
chore(deps-dev): bump from typescript 5.5.4 to 5.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12034,8 +12034,16 @@
     "packages/check-ts-support": {
       "name": "check-lowest-typescript-version",
       "devDependencies": {
+        "@types/node": "~16.11.68",
         "typescript": "4.5.2"
       }
+    },
+    "packages/check-ts-support/node_modules/@types/node": {
+      "version": "16.11.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/check-ts-support/node_modules/typescript": {
       "version": "4.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       ],
       "devDependencies": {
         "@types/eslint": "~8.56.7",
+        "@types/node": "~20.16.5",
         "@typescript-eslint/eslint-plugin": "~8.4.0",
         "@typescript-eslint/parser": "~8.4.0",
         "concurrently": "~8.2.2",
@@ -23,7 +24,7 @@
         "husky": "~9.1.5",
         "lint-staged": "~15.2.10",
         "npm-run-all": "~4.1.5",
-        "typescript": "~5.5.4"
+        "typescript": "~5.6.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2476,10 +2477,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
-      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==",
-      "dev": true
+      "version": "20.16.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
+      "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -11409,10 +11414,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11435,6 +11441,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@types/eslint": "~8.56.7",
+    "@types/node": "~20.16.5",
     "@typescript-eslint/eslint-plugin": "~8.4.0",
     "@typescript-eslint/parser": "~8.4.0",
     "concurrently": "~8.2.2",
@@ -27,7 +28,7 @@
     "husky": "~9.1.5",
     "lint-staged": "~15.2.10",
     "npm-run-all": "~4.1.5",
-    "typescript": "~5.5.4"
+    "typescript": "~5.6.2"
   },
   "lint-staged": {
     "*.{js,cjs,mjs,ts,cts,mts}": [

--- a/packages/check-ts-support/package.json
+++ b/packages/check-ts-support/package.json
@@ -6,6 +6,7 @@
     "test": "tsc --version && tsc"
   },
   "devDependencies": {
+    "@types/node": "~16.11.68",
     "typescript": "4.5.2"
   }
 }


### PR DESCRIPTION
Bump @types/node from 16 to 20 to match the version used to build and fix type incompatibilities with TypeScript 5.6
In the `check-ts-support`, use a version of @types/node compatible with TypeScript 4.5.2