### PR TITLE
chore: correctly include the `lib` folder in the npm package

### DIFF
--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -34,11 +34,11 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "lib"
   ],
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf dist",
+    "clean": "rimraf lib",
     "dev": "tsc --watch --sourceMap",
     "prepack": "run-s clean build",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --runInBand"


### PR DESCRIPTION
Commit 87b969b506c66e1a8735b6255400f6604cb34601 changed the output folder from `dist` to `lib`, but some configurations were not updated accordingly.

In particular, the npm package did not include the `lib` folder. The package could not be consumed correctly because no code was included.


### Notes

Running `npm pack`.

#### Prior the fix

```
npm notice 📦  @process-analytics/bv-experimental-add-ons@0.7.0
npm notice Tarball Contents
npm notice 11.4kB LICENSE
npm notice 5.0kB README.md
npm notice 1.6kB package.json
npm notice Tarball Details
npm notice name: @process-analytics/bv-experimental-add-ons
npm notice version: 0.7.0
npm notice filename: process-analytics-bv-experimental-add-ons-0.7.0.tgz
npm notice package size: 6.5 kB
npm notice unpacked size: 18.0 kB
npm notice shasum: 0535266970dc36f7346c091054c5347d227a6232
npm notice integrity: sha512-VdHIiiBtugQ6n[...]si38apiKo3TrA==
npm notice total files: 3
```

#### With the fix

```
npm notice 📦  @process-analytics/bv-experimental-add-ons@0.7.0
npm notice Tarball Contents
npm notice 11.4kB LICENSE
npm notice 5.0kB README.md
npm notice 2.8kB lib/bpmn-elements.d.ts
npm notice 5.2kB lib/bpmn-elements.js
npm notice 120B lib/index.d.ts
npm notice 678B lib/index.js
npm notice 2.1kB lib/paths.d.ts
npm notice 3.6kB lib/paths.js
npm notice 2.3kB lib/plugins-support.d.ts
npm notice 2.1kB lib/plugins-support.js
npm notice 865B lib/plugins/css-classes.d.ts
npm notice 1.6kB lib/plugins/css-classes.js
npm notice 700B lib/plugins/elements.d.ts
npm notice 1.4kB lib/plugins/elements.js
npm notice 112B lib/plugins/index.d.ts
npm notice 670B lib/plugins/index.js
npm notice 597B lib/plugins/overlays.d.ts
npm notice 2.3kB lib/plugins/overlays.js
npm notice 2.5kB lib/plugins/style.d.ts
npm notice 3.2kB lib/plugins/style.js
npm notice 1.6kB package.json
npm notice Tarball Details
npm notice name: @process-analytics/bv-experimental-add-ons
npm notice version: 0.7.0
npm notice filename: process-analytics-bv-experimental-add-ons-0.7.0.tgz
npm notice package size: 12.3 kB
npm notice unpacked size: 50.7 kB
npm notice shasum: adde1e371e0a9bb532122f8489acf412a3b18cf7
npm notice integrity: sha512-r+JR/t8G1CfJN[...]OIirxnVDwSHWQ==
npm notice total files: 21
```
