### PR TITLE
refactor!: rename Plugin.configure to Plugin.onConfigure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ The central architectural concept is the **plugin system**. This package extends
    - Plugins are passed to `BpmnVisualization` constructor via `options.plugins` array
    - Each plugin is constructed with `(bpmnVisualization, options)` parameters
    - Plugins must implement `getPluginId()` to return a unique identifier
-   - Plugins can optionally implement `configure(options)` for post-construction setup
+   - Plugins can optionally implement the `onConfigure(options)` lifecycle hook for post-construction setup (called by `BpmnVisualization`, not by client code)
    - Retrieve plugins using `bpmnVisualization.getPlugin<PluginType>(pluginId)`
 
 3. **Available Plugins** (in `packages/addons/src/plugins/`):

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ A live demo is available at ⏩ https://process-analytics.github.io/bpmn-visuali
 The sources of the demo are available in the [demo](./packages/demo) folder.
 
 
+## 📚 Documentation
+
+Additional documentation, including the Architecture Decision Records (ADR), is available in the [docs](./docs/README.md) folder.
+
+
 ## ⚒️ Development Setup
 
 Use the node version declared in [.nvmrc](.nvmrc). You can use a Node version manager like [nvm](https://github.com/nvm-sh/nvm): `nvm use`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentation
+
+## Architecture Decision Records (ADR)
+
+We use [Architecture Decision Records](https://adr.github.io/) to capture important architectural decisions, their context, and their consequences.
+
+ADRs live in [`adr/`](./adr) and follow the [MADR (Markdown Any Decision Records)](https://adr.github.io/madr/) format. We chose MADR over the lighter Michael Nygard format because it explicitly captures the considered options and their pros and cons, which makes the rationale behind a decision easier to follow and review.
+
+Each record is numbered and is immutable once accepted: a decision that no longer holds is superseded by a new ADR rather than edited.
+
+### Status legend
+
+- `draft`: still being written, not yet ready for review (editable).
+- `proposed`: content is ready, awaiting team agreement (editable).
+- `accepted`: agreed and in effect (immutable).
+- `rejected`: considered but not adopted (immutable).
+- `deprecated`: no longer relevant, with no direct replacement (immutable).
+- `superseded by ADR-XXXX`: replaced by a newer decision (immutable).
+
+### Records
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](./adr/0001-plugin-support.md) | Plugin support for BpmnVisualization | Draft |

--- a/docs/adr/0001-plugin-support.md
+++ b/docs/adr/0001-plugin-support.md
@@ -1,0 +1,92 @@
+---
+status: draft
+date: 2026-06-24
+---
+
+# Plugin support for BpmnVisualization
+
+## Context and Problem Statement
+
+`bpmn-visualization-addons` extends [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js) with extra functionalities (CSS classes manipulation, overlays management, style manipulation, element search by name, etc.).
+
+These functionalities share two properties:
+
+- They are **optional**. Most consumers of `bpmn-visualization` do not need them, and bundling them unconditionally into the core library would increase its size and surface for every user.
+- They are **driven by the Process Analytics project**, which is a member of the `bpmn-visualization` community rather than the core maintainer of every feature. We need a way to ship and iterate on these features outside the core release cycle, while keeping them cleanly composable with the core.
+
+The core `BpmnVisualization` class does not provide an extension mechanism that lets third parties attach new behavior in a structured, per-instance, opt-in way.
+
+How do we add optional, independently released features to `BpmnVisualization` without coupling them to the core library or forking it?
+
+## Decision Drivers
+
+- Keep optional features out of the core library.
+- Let consumers opt in only to the features they need.
+- Allow several independent features to coexist on the same visualization instance.
+- Give each feature a place to run initialization logic once the instance is ready.
+- Allow the Process Analytics project to develop, version, and release these features independently of the core release cycle.
+
+## Considered Options
+
+1. **Plugin system on top of an extended `BpmnVisualization`** (chosen).
+2. **Fork or monkey-patch the core `BpmnVisualization`** to inject behavior.
+3. **Push every addon into the core `bpmn-visualization` library**.
+
+## Decision Outcome
+
+Chosen option: **"Plugin system on top of an extended `BpmnVisualization`"**, because it keeps optional features opt-in and decoupled from the core, lets independent features coexist, and gives each feature a clear initialization point, while the other options either are fragile (fork/monkey-patch) or couple optional features to the core (push into core).
+
+The plugin system is implemented in `packages/addons/src/plugins-support.ts`:
+
+- The addons package exports its own `BpmnVisualization` class, which extends the one from `bpmn-visualization`. Consumers import `BpmnVisualization` from `@process-analytics/bpmn-visualization-addons` instead of from `bpmn-visualization` to gain plugin support.
+- A `Plugin` interface defines the contract every plugin implements:
+  - `getPluginId()` returns a unique identifier. Registering two plugins with the same id fails fast with an explicit error.
+  - `onConfigure(options)` is an optional lifecycle hook called by `BpmnVisualization` after all plugins have been constructed. It is not intended to be called by client code.
+- Plugins are passed to the constructor through `options.plugins`. They are instantiated with `(bpmnVisualization, options)` and stored in a per-instance registry.
+- Consumers retrieve a plugin with `getPlugin<PluginType>(pluginId)` and then call its methods.
+
+The plugin lifecycle is therefore:
+
+1. **construct**: each plugin class in `options.plugins` is instantiated and registered by its id.
+2. **onConfigure**: once all plugins are registered, the optional `onConfigure(options)` hook of each plugin is invoked.
+
+The features provided by the addons package (`CssClassesPlugin`, `ElementsPlugin`, `OverlaysPlugin`, `StylePlugin`, `StyleByNamePlugin`) are implemented as plugins on top of this infrastructure.
+
+### Consequences
+
+- Good, because optional features stay out of the core library and are opt-in per visualization instance.
+- Good, because multiple independent features can be combined on a single instance without conflicting, thanks to unique plugin ids.
+- Good, because the Process Analytics project can develop, version, and release these addons independently of the core `bpmn-visualization` release cycle.
+- Good, because the model mirrors how `bpmn-visualization` intends to expose functionalities in the future (responsibilities split into dedicated units, better tree-shaking), so addons act as a testing ground for that direction.
+- Good, because each plugin has a clear initialization point through the `onConfigure` lifecycle hook.
+- Bad, because consumers must import `BpmnVisualization` from the addons package, not from `bpmn-visualization`. Mixing the two imports is a common pitfall.
+- Bad, because the addons `BpmnVisualization` is tied to the core class through inheritance, so it must stay compatible with the core API and its declared peer dependency range.
+- Bad, because plugin ids form a shared namespace, and collisions are only detected at registration time (runtime), not at compile time.
+
+## Pros and Cons of the Options
+
+### Plugin system on top of an extended `BpmnVisualization`
+
+- Good, because optional features are opt-in and decoupled from the core.
+- Good, because independent features compose on the same instance.
+- Good, because features can be released independently of the core.
+- Neutral, because it relies on inheritance from the core class.
+- Bad, because consumers must import `BpmnVisualization` from the addons package.
+- Bad, because plugin id collisions are detected only at runtime.
+
+### Fork or monkey-patch the core `BpmnVisualization`
+
+- Good, because it requires no explicit extension point in the core.
+- Bad, because it is fragile and breaks easily when the core changes.
+- Bad, because it is hard to maintain and to combine multiple independent features.
+
+### Push every addon into the core `bpmn-visualization` library
+
+- Good, because consumers have a single import and no separate package.
+- Bad, because it couples optional features to the core and increases its size and surface for every user.
+- Bad, because it forces optional features into the core release cycle, contradicting the goal of separation of responsibilities and improved tree-shaking.
+
+## More Information
+
+- Plugin usage and the list of available plugins: [`packages/addons/README.md`](../../packages/addons/README.md).
+- Implementation: `packages/addons/src/plugins-support.ts`.

--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -76,7 +76,7 @@ in the future, in order to better separate responsibilities and improve tree-sha
 A plugin is defined as a class:
 - It must implement the `Plugin` interface.
 - Its constructor must satisfy the `PluginConstructor` type.
-- It can implement the `configure` method to configure the plugin after construction.
+- It can implement the `onConfigure` lifecycle method to configure the plugin after construction. This method is called by `BpmnVisualization` and is not intended to be called by client code.
 - It can provide new methods to extend existing API or introduce new behavior .
 
 

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -25,17 +25,19 @@ export type PluginConstructor = new (bpmnVisualization: BpmnVisualization, optio
 /**
  * Plugin lifecycle:
  *   - construct
- *   - configure
+ *   - onConfigure
  */
 export interface Plugin {
   /** Returns the unique identifier of the plugin. It is not possible to use several plugins having the same identifier. */
   getPluginId(): string;
 
   /**
+   * Lifecycle hook called by {@link BpmnVisualization} after all plugins have been constructed. It is not intended to be called by client code.
+   *
    * Implement this method to configure the plugin after initialization.
    * @param options The options passed to the BpmnVisualization instance, used to configure the plugin.
    */
-  configure?: (options: GlobalOptions) => void;
+  onConfigure?: (options: GlobalOptions) => void;
 }
 
 /**
@@ -93,7 +95,7 @@ export class BpmnVisualization extends BaseBpmnVisualization {
 
     // configure
     for (const plugin of this.plugins.values()) {
-      plugin.configure?.(options);
+      plugin.onConfigure?.(options);
     }
   };
 }

--- a/packages/addons/test/spec/plugins-support.test.ts
+++ b/packages/addons/test/spec/plugins-support.test.ts
@@ -118,7 +118,7 @@ describe('Ensure that plugins are configured', () => {
       return this.#customValue;
     }
 
-    configure(options: CustomGlobalOptions): void {
+    onConfigure(options: CustomGlobalOptions): void {
       this.#isConfigured = true;
       this.#customValue = options.customValue ?? 'no passed in options';
     }


### PR DESCRIPTION
## Why

The `Plugin` interface exposed an optional `configure(options)` method. The name did not convey that it is a lifecycle step invoked by `BpmnVisualization` after all plugins have been constructed: it could be mistaken for an API that client code is meant to call directly.

This PR also documents the plugin support itself through an Architecture Decision Record, so the rationale behind the design (optional features provided by the Process Analytics community project) is captured alongside the code.

## What

### Rename `Plugin.configure` to `Plugin.onConfigure`

The `on` prefix follows the common naming convention for framework-invoked lifecycle callbacks and makes the intent explicit. The signature is unchanged.

Updated accordingly:
- `Plugin` interface and the internal invocation in `packages/addons/src/plugins-support.ts` (JSDoc now states it is a framework-called hook, not for client code)
- the test plugin in `packages/addons/test/spec/plugins-support.test.ts`
- documentation: `packages/addons/README.md` and `CLAUDE.md`

### Document the plugin support with an ADR

- Add `docs/adr/0001-plugin-support.md` (MADR format) explaining why the optional features provided by the Process Analytics project are implemented as opt-in plugins rather than forked into or pushed to the core `bpmn-visualization` library.
- Add `docs/README.md` indexing the ADRs and describing the chosen format and the status conventions.
- Reference the docs folder from the main `README.md`.

The ADR is currently in `draft` status.

## Breaking change

Plugins implementing the optional `configure(options)` method must rename it to `onConfigure(options)`. Only the method name changes; the signature is identical.

## Validation

- `npm run build -w packages/addons`: OK
- `npm test -w packages/addons`: 100 tests passing
- `npm run lint-check`: OK
