### PR TITLE
feat: add plugin lifecycle hooks for load and dispose

### DIFF
--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -76,8 +76,53 @@ in the future, in order to better separate responsibilities and improve tree-sha
 A plugin is defined as a class:
 - It must implement the `Plugin` interface.
 - Its constructor must satisfy the `PluginConstructor` type.
-- It can implement the `onConfigure` lifecycle method to configure the plugin after construction. This method is called by `BpmnVisualization` and is not intended to be called by client code.
-- It can provide new methods to extend existing API or introduce new behavior .
+- It can provide new methods to extend existing API or introduce new behavior.
+- It can implement the optional lifecycle hooks below. They are all called by `BpmnVisualization` and are not intended to be called by client code:
+  - `onConfigure`: configure the plugin after construction, once all plugins have been constructed.
+  - `onBeforeLoad`: called at the beginning of each `load` call, before the BPMN source is processed.
+  - `onLoadSuccess`: called after a `load` call has succeeded.
+  - `onLoadError`: called with the thrown error when a `load` call fails, before the error is rethrown to the caller.
+  - `onDispose`: called when the `BpmnVisualization` instance is disposed, before the underlying resources are released.
+
+##### Passing options to a plugin with `onConfigure`
+
+`onConfigure` receives the options passed to the `BpmnVisualization` constructor. To pass your own properties in a
+type-safe way, use [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation)
+to extend the `bpmn-visualization` `GlobalOptions` interface.
+
+To avoid name clashes with `bpmn-visualization` options or with other plugins, wrap your properties in a single
+dedicated object named after your plugin (here `myCustomPlugin`):
+
+```ts
+import {BpmnVisualization, Plugin} from "@process-analytics/bpmn-visualization-addons";
+import type {GlobalOptions} from "bpmn-visualization";
+
+declare module "bpmn-visualization" {
+    interface GlobalOptions {
+        myCustomPlugin?: {
+            property1: string;
+        };
+    }
+}
+
+class MyCustomPlugin implements Plugin {
+    getPluginId(): string {
+        return "my-custom-plugin";
+    }
+
+    onConfigure(options: GlobalOptions): void {
+        // read your namespaced options
+        const property1 = options.myCustomPlugin?.property1;
+        // ... configure the plugin with property1
+    }
+}
+
+const bpmnVisualization = new BpmnVisualization({
+    container: "bpmn-container",
+    plugins: [MyCustomPlugin],
+    myCustomPlugin: {property1: "a value"}
+});
+```
 
 
 ### `BpmnElementsIdentifier`

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BpmnVisualization as BaseBpmnVisualization, type GlobalOptions } from 'bpmn-visualization';
+import { BpmnVisualization as BaseBpmnVisualization, type LoadOptions, type GlobalOptions } from 'bpmn-visualization';
 
 /**
  * Enforce the Plugin constructor signature.
@@ -23,9 +23,12 @@ import { BpmnVisualization as BaseBpmnVisualization, type GlobalOptions } from '
 export type PluginConstructor = new (bpmnVisualization: BpmnVisualization, options: GlobalOptions) => Plugin;
 
 /**
- * Plugin lifecycle:
+ * Plugin lifecycle. All hooks except {@link Plugin.getPluginId} are optional and are called by {@link BpmnVisualization},
+ * not by client code:
  *   - construct
- *   - onConfigure
+ *   - {@link Plugin.onConfigure}: once, after all plugins have been constructed
+ *   - {@link Plugin.onBeforeLoad} / {@link Plugin.onLoadSuccess} / {@link Plugin.onLoadError}: on each `load` call
+ *   - {@link Plugin.onDispose}: when the {@link BpmnVisualization} instance is disposed
  */
 export interface Plugin {
   /** Returns the unique identifier of the plugin. It is not possible to use several plugins having the same identifier. */
@@ -38,6 +41,32 @@ export interface Plugin {
    * @param options The options passed to the BpmnVisualization instance, used to configure the plugin.
    */
   onConfigure?: (options: GlobalOptions) => void;
+
+  /**
+   * Lifecycle hook called by {@link BpmnVisualization} when the instance is disposed, before the underlying resources are released.
+   * @since 0.10.0
+   */
+  onDispose?: () => void;
+
+  /**
+   * Lifecycle hook called by {@link BpmnVisualization} at the beginning of each `load` call, before the BPMN source is processed.
+   * @since 0.10.0
+   */
+  onBeforeLoad?: () => void;
+
+  /**
+   * Lifecycle hook called by {@link BpmnVisualization} after a `load` call has succeeded. It is not called when the load fails;
+   * in that case, {@link Plugin.onLoadError} is called instead.
+   * @since 0.10.0
+   */
+  onLoadSuccess?: () => void;
+
+  /**
+   * Lifecycle hook called by {@link BpmnVisualization} when a `load` call fails, before the error is rethrown to the caller.
+   * @param error The error thrown while loading the BPMN source.
+   * @since 0.10.0
+   */
+  onLoadError?: (error: unknown) => void;
 }
 
 declare module 'bpmn-visualization' {
@@ -72,6 +101,22 @@ export class BpmnVisualization extends BaseBpmnVisualization {
     this.registerPlugins(options);
   }
 
+  override dispose(): void {
+    this.forEachPlugin(plugin => plugin.onDispose?.());
+    super.dispose();
+  }
+
+  override load(xml: string, options?: LoadOptions): void {
+    this.forEachPlugin(plugin => plugin.onBeforeLoad?.());
+    try {
+      super.load(xml, options);
+    } catch (error) {
+      this.forEachPlugin(plugin => plugin.onLoadError?.(error));
+      throw error;
+    }
+    this.forEachPlugin(plugin => plugin.onLoadSuccess?.());
+  }
+
   getPlugin<T extends Plugin>(id: PluginIds): T {
     return this.plugins.get(id) as T;
   }
@@ -90,6 +135,12 @@ export class BpmnVisualization extends BaseBpmnVisualization {
     // configure
     for (const plugin of this.plugins.values()) {
       plugin.onConfigure?.(options);
+    }
+  };
+
+  private readonly forEachPlugin = (functor: (plugin: Plugin) => void): void => {
+    for (const plugin of this.plugins.values()) {
+      functor(plugin);
     }
   };
 }

--- a/packages/addons/test/spec/plugins-support.test.ts
+++ b/packages/addons/test/spec/plugins-support.test.ts
@@ -17,10 +17,12 @@ limitations under the License.
 import type { Plugin } from '../../src/index.js';
 import type { GlobalOptions } from 'bpmn-visualization';
 
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, jest, test } from '@jest/globals';
 
 import { BpmnVisualization } from '../../src/index.js';
 import { createNewBpmnVisualizationWithoutContainer } from '../shared/bv-utilities.js';
+import { insertBpmnContainerWithoutId } from '../shared/dom-utilities.js';
+import { readFileSync } from '../shared/io-utilities.js';
 
 test('No error when no plugin is defined', () => {
   const bpmnVisualization = createNewBpmnVisualizationWithoutContainer();
@@ -104,6 +106,9 @@ describe('Prevent multiple plugins with the same ID from loading', () => {
 });
 
 describe('Ensure that plugins are configured', () => {
+  // Use a local intersection type instead of module augmentation of GlobalOptions: augmentation is global, so it would
+  // leak the custom property to all tests and risk side effects. In application code, module augmentation is the
+  // recommended way to pass custom properties to a plugin (see the README).
   type CustomGlobalOptions = GlobalOptions & {
     customValue?: string;
   };
@@ -139,5 +144,111 @@ describe('Ensure that plugins are configured', () => {
     const configurablePlugin = bpmnVisualization.getPlugin<ConfigurablePlugin>('custom-configurable-plugin');
     expect(configurablePlugin.isConfigured).toBeTruthy();
     expect(configurablePlugin.customValue).toBe('custom in options'); // ensure that the options are passed to the plugin configuration
+  });
+});
+
+/**
+ * A plugin that implements none of the optional lifecycle methods. It is used in the tests checking that no error
+ * occurs when a registered plugin doesn't implement the optional method involved in a given lifecycle step.
+ */
+class PluginWithoutOptionalMethods implements Plugin {
+  getPluginId(): string {
+    return 'custom-plugin-without-optional-methods';
+  }
+}
+
+describe('Ensure that plugins are disposed', () => {
+  class DisposablePlugin1 implements Plugin {
+    onDispose = jest.fn();
+
+    getPluginId(): string {
+      return 'custom-disposable-plugin-1';
+    }
+  }
+
+  class DisposablePlugin2 implements Plugin {
+    onDispose = jest.fn();
+
+    getPluginId(): string {
+      return 'custom-disposable-plugin-2';
+    }
+  }
+
+  test('Call onDispose on plugins that implement it and ignore the others when disposing BpmnVisualization', () => {
+    const bpmnVisualization = new BpmnVisualization({ container: undefined!, plugins: [DisposablePlugin1, PluginWithoutOptionalMethods, DisposablePlugin2] });
+    const disposablePlugin1 = bpmnVisualization.getPlugin<DisposablePlugin1>('custom-disposable-plugin-1');
+    const disposablePlugin2 = bpmnVisualization.getPlugin<DisposablePlugin2>('custom-disposable-plugin-2');
+
+    expect(() => bpmnVisualization.dispose()).not.toThrow();
+    expect(disposablePlugin1.onDispose).toHaveBeenCalledTimes(1);
+    expect(disposablePlugin2.onDispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+class LoadAwarePlugin1 implements Plugin {
+  onBeforeLoad = jest.fn();
+  onLoadSuccess = jest.fn();
+  onLoadError = jest.fn();
+
+  getPluginId(): string {
+    return 'custom-load-aware-plugin-1';
+  }
+}
+
+class LoadAwarePlugin2 implements Plugin {
+  onBeforeLoad = jest.fn();
+  onLoadSuccess = jest.fn();
+  onLoadError = jest.fn();
+
+  getPluginId(): string {
+    return 'custom-load-aware-plugin-2';
+  }
+}
+
+const validBpmnContent = readFileSync('./fixtures/bpmn/search-elements.bpmn');
+const invalidBpmnContent = 'this is not valid BPMN content';
+
+const setupLoadAwareVisualization = (): { bpmnVisualization: BpmnVisualization; loadAwarePlugin1: LoadAwarePlugin1; loadAwarePlugin2: LoadAwarePlugin2 } => {
+  const bpmnVisualization = new BpmnVisualization({ container: insertBpmnContainerWithoutId(), plugins: [LoadAwarePlugin1, PluginWithoutOptionalMethods, LoadAwarePlugin2] });
+  return {
+    bpmnVisualization,
+    loadAwarePlugin1: bpmnVisualization.getPlugin<LoadAwarePlugin1>('custom-load-aware-plugin-1'),
+    loadAwarePlugin2: bpmnVisualization.getPlugin<LoadAwarePlugin2>('custom-load-aware-plugin-2'),
+  };
+};
+
+describe('Ensure that plugins are notified before load', () => {
+  test('Call onBeforeLoad on plugins that implement it and ignore the others when loading with BpmnVisualization', () => {
+    const { bpmnVisualization, loadAwarePlugin1, loadAwarePlugin2 } = setupLoadAwareVisualization();
+
+    expect(() => bpmnVisualization.load(validBpmnContent)).not.toThrow();
+    expect(loadAwarePlugin1.onBeforeLoad).toHaveBeenCalledTimes(1);
+    expect(loadAwarePlugin2.onBeforeLoad).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Ensure that plugins are notified on load success', () => {
+  test('Call onLoadSuccess on plugins that implement it and ignore the others when loading with BpmnVisualization', () => {
+    const { bpmnVisualization, loadAwarePlugin1, loadAwarePlugin2 } = setupLoadAwareVisualization();
+
+    expect(() => bpmnVisualization.load(validBpmnContent)).not.toThrow();
+    expect(loadAwarePlugin1.onLoadSuccess).toHaveBeenCalledTimes(1);
+    expect(loadAwarePlugin2.onLoadSuccess).toHaveBeenCalledTimes(1);
+    expect(loadAwarePlugin1.onLoadError).not.toHaveBeenCalled();
+    expect(loadAwarePlugin2.onLoadError).not.toHaveBeenCalled();
+  });
+});
+
+describe('Ensure that plugins are notified on load error', () => {
+  test('Call onLoadError on plugins that implement it, rethrow and skip onLoadSuccess when loading fails', () => {
+    const { bpmnVisualization, loadAwarePlugin1, loadAwarePlugin2 } = setupLoadAwareVisualization();
+
+    expect(() => bpmnVisualization.load(invalidBpmnContent)).toThrow();
+    expect(loadAwarePlugin1.onBeforeLoad).toHaveBeenCalledTimes(1);
+    expect(loadAwarePlugin2.onBeforeLoad).toHaveBeenCalledTimes(1);
+    expect(loadAwarePlugin1.onLoadError).toHaveBeenCalledTimes(1);
+    expect(loadAwarePlugin2.onLoadError).toHaveBeenCalledTimes(1);
+    expect(loadAwarePlugin1.onLoadSuccess).not.toHaveBeenCalled();
+    expect(loadAwarePlugin2.onLoadSuccess).not.toHaveBeenCalled();
   });
 });

--- a/packages/addons/test/spec/plugins-support.test.ts
+++ b/packages/addons/test/spec/plugins-support.test.ts
@@ -248,6 +248,8 @@ describe('Ensure that plugins are notified on load error', () => {
     expect(loadAwarePlugin2.onBeforeLoad).toHaveBeenCalledTimes(1);
     expect(loadAwarePlugin1.onLoadError).toHaveBeenCalledTimes(1);
     expect(loadAwarePlugin2.onLoadError).toHaveBeenCalledTimes(1);
+    expect(loadAwarePlugin1.onLoadError).toHaveBeenCalledWith(expect.any(Error));
+    expect(loadAwarePlugin2.onLoadError).toHaveBeenCalledWith(expect.any(Error));
     expect(loadAwarePlugin1.onLoadSuccess).not.toHaveBeenCalled();
     expect(loadAwarePlugin2.onLoadSuccess).not.toHaveBeenCalled();
   });

--- a/packages/addons/tsconfig.json
+++ b/packages/addons/tsconfig.json
@@ -97,7 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+     "noImplicitOverride": true,                         /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */


### PR DESCRIPTION
## What

Extend the plugin system with four new optional lifecycle hooks on the `Plugin` interface, so plugins can react to the `BpmnVisualization` lifecycle without any client code wiring:

- `onDispose`: called when the instance is disposed, before the underlying resources are released.
- `onBeforeLoad`: called at the start of each `load`, before the BPMN source is processed.
- `onLoadSuccess`: called after a `load` has succeeded.
- `onLoadError(error)`: called with the thrown error when a `load` fails, before the error is rethrown to the caller.

## Why

Until now the only lifecycle hook was `onConfigure` (post-construction). Plugins had no way to run logic around load and dispose, which are the two key moments where a plugin typically needs to set up, refresh, or release resources. These hooks fill that gap while keeping everything opt-in: a plugin implements only the hooks it needs, and plugins without a given hook are simply skipped.

## How

- `BpmnVisualization` overrides `dispose()` and `load()` and notifies every registered plugin through a shared `forEachPlugin` helper.
- `load()` wraps the delegation to `super.load()` in a `try/catch`: on failure it calls `onLoadError` then rethrows, so callers still observe the error; `onLoadSuccess` only runs on the success path. `onBeforeLoad` always runs first.
- `noImplicitOverride` is enabled in `tsconfig` to enforce the `override` modifier on the new overrides.

## Naming

`onLoadSuccess` is named for the success-only contract (it is intentionally skipped on error), pairing clearly with `onLoadError`. `onLoadError` receives the caught error so plugins can react to what failed.

## Documentation

The README documents all five hooks and adds a worked example showing how to pass options to a plugin via `onConfigure` using module augmentation of `GlobalOptions`, namespacing properties under a per-plugin object to avoid name clashes.

## Tests

Added coverage for each hook: that the hook fires the expected number of times, that plugins missing the hook are ignored without error, and the success/error exclusivity (success does not trigger `onLoadError`, and a failing load still triggers `onBeforeLoad` while skipping `onLoadSuccess`).