### PR TITLE
docs: document load and dispose lifecycle hooks

### DIFF
--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -124,6 +124,35 @@ const bpmnVisualization = new BpmnVisualization({
 });
 ```
 
+##### Cleaning up resources with `onDispose`
+
+`onDispose` aligns plugin lifecycle management with the disposal capabilities of the core `bpmn-visualization` library.
+Implement it to release everything the plugin acquired, so the `BpmnVisualization` instance can be garbage collected and no
+work keeps running after disposal. Typical cleanup includes:
+
+- removing DOM or graph event listeners registered by the plugin;
+- clearing timers or intervals (`clearTimeout` / `clearInterval`);
+- dropping references to the `BpmnVisualization` instance and to BPMN elements;
+- discarding cached data or other internal state held by the plugin.
+
+The hook runs before the core resources are released, so the `BpmnVisualization` instance and the BPMN model are still
+accessible if cleanup requires them.
+
+```ts
+class MyCustomPlugin implements Plugin {
+    private readonly intervalId = setInterval(() => this.refresh(), 1000);
+
+    getPluginId(): string {
+        return "my-custom-plugin";
+    }
+
+    onDispose(): void {
+        clearInterval(this.intervalId);
+        // remove listeners, drop references and cached state here as well
+    }
+}
+```
+
 
 ### `BpmnElementsIdentifier`
 

--- a/packages/addons/README.md
+++ b/packages/addons/README.md
@@ -124,6 +124,43 @@ const bpmnVisualization = new BpmnVisualization({
 });
 ```
 
+##### Reacting to BPMN loading with the load hooks
+
+The `onBeforeLoad`, `onLoadSuccess` and `onLoadError` hooks let a plugin react to each `load` call, so it can keep its own
+state in sync with the BPMN model currently rendered. They run around `BpmnVisualization.load`:
+
+- `onBeforeLoad`: runs before the new BPMN source is processed, while the previous model is still rendered. Use it to reset
+  state tied to the outgoing model, for example clearing caches, removing overlays or CSS classes, or discarding indexes
+  built from the previous diagram.
+- `onLoadSuccess`: runs after the new model has been rendered. Use it to (re)build state from the freshly loaded diagram,
+  for example indexing elements, registering event listeners, or applying default styles and overlays.
+- `onLoadError`: runs with the thrown error when loading fails, before the error is rethrown to the caller. Use it to roll
+  back any partial work started in `onBeforeLoad` and to report or log the failure. It does not swallow the error.
+
+`load` can be called several times on the same instance, so these hooks may run more than once. Make sure work done in
+`onLoadSuccess` is cleaned up in a later `onBeforeLoad` (or in `onDispose`) to avoid leaking state across loads.
+
+```ts
+class MyCustomPlugin implements Plugin {
+    getPluginId(): string {
+        return "my-custom-plugin";
+    }
+
+    onBeforeLoad(): void {
+        // reset state tied to the previously loaded model
+    }
+
+    onLoadSuccess(): void {
+        // build state from the freshly loaded model (indexes, listeners, styles, ...)
+    }
+
+    onLoadError(error: unknown): void {
+        // roll back partial work and report the failure
+        console.error("BPMN load failed", error);
+    }
+}
+```
+
 ##### Cleaning up resources with `onDispose`
 
 `onDispose` aligns plugin lifecycle management with the disposal capabilities of the core `bpmn-visualization` library.

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -62,19 +62,33 @@ export interface Plugin {
 
   /**
    * Lifecycle hook called by {@link BpmnVisualization} at the beginning of each `load` call, before the BPMN source is processed.
+   * It is not intended to be called by client code.
+   *
+   * Runs while the previous model is still rendered. Implement it to reset state tied to the outgoing model, for example
+   * clearing caches, removing overlays or CSS classes, or discarding indexes built from the previous diagram.
+   *
+   * `load` can be called several times on the same instance, so this hook may run more than once.
    * @since 0.10.0
    */
   onBeforeLoad?: () => void;
 
   /**
    * Lifecycle hook called by {@link BpmnVisualization} after a `load` call has succeeded. It is not called when the load fails;
-   * in that case, {@link Plugin.onLoadError} is called instead.
+   * in that case, {@link Plugin.onLoadError} is called instead. It is not intended to be called by client code.
+   *
+   * Runs after the new model has been rendered. Implement it to (re)build state from the freshly loaded diagram, for example
+   * indexing elements, registering event listeners, or applying default styles and overlays. Clean up this work in a later
+   * {@link Plugin.onBeforeLoad} or in {@link Plugin.onDispose} to avoid leaking state across loads.
    * @since 0.10.0
    */
   onLoadSuccess?: () => void;
 
   /**
    * Lifecycle hook called by {@link BpmnVisualization} when a `load` call fails, before the error is rethrown to the caller.
+   * It is not intended to be called by client code.
+   *
+   * Implement it to roll back any partial work started in {@link Plugin.onBeforeLoad} and to report or log the failure.
+   * It does not swallow the error: the original error is still rethrown to the caller.
    * @param error The error thrown while loading the BPMN source.
    * @since 0.10.0
    */

--- a/packages/addons/src/plugins-support.ts
+++ b/packages/addons/src/plugins-support.ts
@@ -44,6 +44,18 @@ export interface Plugin {
 
   /**
    * Lifecycle hook called by {@link BpmnVisualization} when the instance is disposed, before the underlying resources are released.
+   * It is not intended to be called by client code.
+   *
+   * This hook aligns plugin lifecycle management with the disposal capabilities of the core `bpmn-visualization` library.
+   * Implement it to release everything the plugin acquired so the `BpmnVisualization` instance can be garbage collected and
+   * no work continues after disposal. Typical cleanup includes:
+   *   - removing DOM or graph event listeners registered by the plugin;
+   *   - clearing timers or intervals (`clearTimeout` / `clearInterval`);
+   *   - dropping references to the {@link BpmnVisualization} instance and to BPMN elements;
+   *   - discarding cached data or other internal state held by the plugin.
+   *
+   * It runs before the core resources are released, so the {@link BpmnVisualization} instance and the BPMN model are still
+   * accessible if cleanup requires them.
    * @since 0.10.0
    */
   onDispose?: () => void;


### PR DESCRIPTION
Clarify when and why plugin authors should implement the plugin lifecycle hooks, both in the `Plugin` interface JSDoc and in the addons README. This covers the `onDispose` hook and the three load hooks (`onBeforeLoad`, `onLoadSuccess`, `onLoadError`).

## Why

The previous wording only stated *when* each hook runs. Plugin authors had no guidance on *what* to do in them, which matters for avoiding leaks and keeping plugin state in sync with the rendered BPMN model.

## What changed

### `onDispose`

- Document the typical cleanup cases: DOM/graph event listeners, timers/intervals, references to the `BpmnVisualization` instance, and cached/internal state.
- Note that the hook aligns plugin lifecycle management with the disposal capabilities introduced in the core library.
- Clarify that the hook runs before core resources are released, so the instance and BPMN model are still accessible during cleanup.

### Load hooks (`onBeforeLoad` / `onLoadSuccess` / `onLoadError`)

- Describe what each is for: reset state tied to the outgoing model, (re)build state from the freshly loaded model, and roll back partial work on failure.
- Note that `load` can run several times, so the hooks may run more than once, and that load-time work must be cleaned up in a later `onBeforeLoad` or in `onDispose`.
- Clarify that `onLoadError` does not swallow the error: it is still rethrown to the caller.

### Both

- Align the JSDoc by noting the hooks are not intended to be called by client code.
- Add README examples and order the subsections to follow the lifecycle steps (`onConfigure`, load hooks, `onDispose`).