### PR TITLE
fix(demo): correct lib chunk name extraction in list-lib-chunks.sh

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/deploy-demo.yml'
       - 'packages/addons/src/**/*'
       - 'packages/addons/**/*.json'
+      - 'packages/demo/scripts/list-lib-chunks.sh'
       - 'packages/demo/src/**/*'
       - 'packages/demo/**/*.json'
       - 'packages/demo/**/*.html'

--- a/.github/workflows/deploy-pr-demo.yml
+++ b/.github/workflows/deploy-pr-demo.yml
@@ -11,6 +11,7 @@ on:
       - '.github/workflows/deploy-pr-demo.yml'
       - 'packages/addons/src/**/*'
       - 'packages/addons/**/*.json'
+      - 'packages/demo/scripts/list-lib-chunks.sh'
       - 'packages/demo/src/**/*'
       - 'packages/demo/**/*.json'
       - 'packages/demo/**/*.html'

--- a/packages/demo/scripts/list-lib-chunks.sh
+++ b/packages/demo/scripts/list-lib-chunks.sh
@@ -26,7 +26,9 @@ for file in "$DIST_DIR"/lib-*.js; do
   [[ -f "$file" ]] || continue
   filename=$(basename "$file")
   # Extract dependency name: lib-<name>-<hash>.js -> <name>
-  dep_name=$(echo "$filename" | sed 's/^lib-//;s/-[^-]*\.js$//')
+  # The hash is an 8-char URL-safe base64 string that may itself contain hyphens
+  # (e.g. lib-mxgraph-8p-_dQzY.js), so strip exactly the trailing -<8 chars>.js.
+  dep_name=$(echo "$filename" | sed 's/^lib-//;s/-[A-Za-z0-9_-]\{8\}\.js$//')
   size_kb=$(LC_NUMERIC=C awk "BEGIN {printf \"%.2f\", $(stat --format=%s "$file") / 1000}")
   names+=("$dep_name")
   sizes+=("$size_kb")


### PR DESCRIPTION
## Problem

Running `./scripts/list-lib-chunks.sh` from `packages/demo` reported the mxgraph dependency as `mxgraph-8p` instead of `mxgraph`.

The script derives the dependency name from the built chunk filename `lib-<name>-<hash>.js`. Rolldown chunk hashes are 8-character URL-safe base64 strings that may contain hyphens, e.g. `lib-mxgraph-8p-_dQzY.js` (hash `8p-_dQzY`). The previous extraction `sed 's/-[^-]*\.js$//'` stripped only the last hyphen-delimited segment (`-_dQzY.js`), leaving `mxgraph-8p`.

## Fix

Match the trailing `-<8 chars>.js` using the full hash character class `[A-Za-z0-9_-]{8}`, so hyphens inside the hash no longer break the dependency name extraction.

## Verification

Ran `./scripts/list-lib-chunks.sh` and confirmed all four chunks resolve correctly:

```
bpmn-visualization        100.78 kB
es-toolkit                0.84 kB
fast-xml-parser           56.68 kB
mxgraph                   833.74 kB
TOTAL                     992.04 kB
```

Note: this assumes the rolldown hash stays at 8 characters (its current default).
