### PR TITLE
docs(adr): document load and dispose lifecycle hooks

### DIFF
--- a/docs/adr/0001-plugin-support.md
+++ b/docs/adr/0001-plugin-support.md
@@ -24,6 +24,7 @@ How do we add optional, independently released features to `BpmnVisualization` w
 - Let consumers opt in only to the features they need.
 - Allow several independent features to coexist on the same visualization instance.
 - Give each feature a place to run initialization logic once the instance is ready.
+- Let each feature react to the `BpmnVisualization` lifecycle (load and disposal) without any client code wiring.
 - Allow the Process Analytics project to develop, version, and release these features independently of the core release cycle.
 
 ## Considered Options
@@ -39,9 +40,13 @@ Chosen option: **"Plugin system on top of an extended `BpmnVisualization`"**, be
 The plugin system is implemented in `packages/addons/src/plugins-support.ts`:
 
 - The addons package exports its own `BpmnVisualization` class, which extends the one from `bpmn-visualization`. Consumers import `BpmnVisualization` from `@process-analytics/bpmn-visualization-addons` instead of from `bpmn-visualization` to gain plugin support.
-- A `Plugin` interface defines the contract every plugin implements:
+- A `Plugin` interface defines the contract every plugin implements. Only `getPluginId()` is mandatory; every other hook is optional and is called by `BpmnVisualization`, not by client code:
   - `getPluginId()` returns a unique identifier. Registering two plugins with the same id fails fast with an explicit error.
-  - `onConfigure(options)` is an optional lifecycle hook called by `BpmnVisualization` after all plugins have been constructed. It is not intended to be called by client code.
+  - `onConfigure(options)` runs once, after all plugins have been constructed. Implement it to configure the plugin from the `GlobalOptions` passed to the instance.
+  - `onBeforeLoad()` runs at the beginning of each `load` call, before the BPMN source is processed and while the previous model is still rendered. Implement it to reset state tied to the outgoing model.
+  - `onLoadSuccess()` runs after a `load` call has succeeded and the new model has been rendered. Implement it to (re)build state from the freshly loaded diagram.
+  - `onLoadError(error)` runs when a `load` call fails, before the error is rethrown to the caller. Implement it to roll back partial work; it does not swallow the error.
+  - `onDispose()` runs when the instance is disposed, before the underlying core resources are released, so the instance and the BPMN model are still accessible. Implement it to release everything the plugin acquired.
 - Plugins are passed to the constructor through `options.plugins`. They are instantiated with `(bpmnVisualization, options)` and stored in a per-instance registry.
 - Consumers retrieve a plugin with `getPlugin<PluginType>(pluginId)` and then call its methods.
 
@@ -49,6 +54,8 @@ The plugin lifecycle is therefore:
 
 1. **construct**: each plugin class in `options.plugins` is instantiated and registered by its id.
 2. **onConfigure**: once all plugins are registered, the optional `onConfigure(options)` hook of each plugin is invoked.
+3. **load hooks**: on each `load` call, `onBeforeLoad` fires before processing the BPMN source, then either `onLoadSuccess` (on success) or `onLoadError(error)` (on failure, before the error is rethrown). `load` can be called several times, so these hooks may run more than once.
+4. **onDispose**: when the instance is disposed, `onDispose` fires before the core resources are released.
 
 The features provided by the addons package (`CssClassesPlugin`, `ElementsPlugin`, `OverlaysPlugin`, `StylePlugin`, `StyleByNamePlugin`) are implemented as plugins on top of this infrastructure.
 
@@ -59,6 +66,7 @@ The features provided by the addons package (`CssClassesPlugin`, `ElementsPlugin
 - Good, because the Process Analytics project can develop, version, and release these addons independently of the core `bpmn-visualization` release cycle.
 - Good, because the model mirrors how `bpmn-visualization` intends to expose functionalities in the future (responsibilities split into dedicated units, better tree-shaking), so addons act as a testing ground for that direction.
 - Good, because each plugin has a clear initialization point through the `onConfigure` lifecycle hook.
+- Good, because plugins can react to the load and disposal lifecycle (`onBeforeLoad`, `onLoadSuccess`, `onLoadError`, `onDispose`) without any client code wiring, so they can reset, rebuild, or release their state in step with the instance.
 - Bad, because consumers must import `BpmnVisualization` from the addons package, not from `bpmn-visualization`. Mixing the two imports is a common pitfall.
 - Bad, because the addons `BpmnVisualization` is tied to the core class through inheritance, so it must stay compatible with the core API and its declared peer dependency range.
 - Bad, because plugin ids form a shared namespace, and collisions are only detected at registration time (runtime), not at compile time.


### PR DESCRIPTION
Aligns the plugin support ADR (`docs/adr/0001-plugin-support.md`) with the current implementation.

## Problem

Commit 58a24464 (`feat: add plugin lifecycle hooks for load and dispose`, #540) added four optional hooks to the `Plugin` interface: `onBeforeLoad`, `onLoadSuccess`, `onLoadError`, `onDispose`. The ADR still only described the `construct` and `onConfigure` steps, so it no longer matched the code.

## Changes

- **Plugin interface contract**: expanded to list all six hooks, using the descriptions from the `Plugin` interface JSDoc (source of truth).
- **Lifecycle enumeration**: extended from 2 steps to 4, covering the per-load hooks (noting `load` can run multiple times and that `onLoadError` fires before the error is rethrown) and disposal.
- **Decision Drivers**: added a driver about reacting to the load/dispose lifecycle without client code wiring.
- **Consequences**: added a matching "Good, because" point.

`status` stays `draft`.

## Verification

Each hook described in the ADR was cross-checked against the real signatures in `packages/addons/src/plugins-support.ts`.